### PR TITLE
Add missing AEnum case to printAccess method

### DIFF
--- a/src/godot/haxestd/Printer.hx
+++ b/src/godot/haxestd/Printer.hx
@@ -195,7 +195,9 @@ class Printer {
 			case AExtern: "extern";
 			case AAbstract: "abstract";
 			case AOverload: "overload";
+			#if(haxe >= "5.0.0")
 			case AEnum: "enum";
+			#end
 		}
 
 	/// MODIFIED!!

--- a/src/godot/haxestd/Printer.hx
+++ b/src/godot/haxestd/Printer.hx
@@ -195,6 +195,7 @@ class Printer {
 			case AExtern: "extern";
 			case AAbstract: "abstract";
 			case AOverload: "overload";
+			case AEnum: "enum";
 		}
 
 	/// MODIFIED!!


### PR DESCRIPTION
Prevents failure with enum exhaustiveness error at `haxelib run godot-api-generator` stage of setup instruction