### PR TITLE
Addons and Signals support, minor refactor !! also Spanish Readme :sob:

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,139 @@
+# Generador de Bindings de Godot para Haxe
+
+_Genera bindings de Godot agnósticos al target para Haxe._
+
+La mayoría de los generadores de bindings de Godot para Haxe están diseñados para un target específico (Haxe/C++, Haxe/C#, etc.). El objetivo de este proyecto es crear bindings genéricos que puedan servir como _base_ para otros proyectos y evitar reinventar la rueda.
+
+Esto se logra convirtiendo los datos de `extension_api.json` de Godot a representaciones [`TypeDefinition`](https://api.haxe.org/haxe/macro/TypeDefinition.html) de los tipos Haxe generados. Desde ahí, puedes manipular los `TypeDefinition`s para que funcionen mejor con tu target de Haxe deseado. Este proyecto se encargará de generar los archivos `.hx`.
+
+¡Si solo quieres bindings básicos de Godot sin modificar, también puedes hacerlo!
+
+&nbsp;
+
+## Bindings para Addons de GDScript
+
+Cuando trabajas con Haxe en Godot, frecuentemente necesitas interactuar con addons basados en GDScript (como sistemas de diálogos, máquinas de estado, etc.). Normalmente esto requiere escribir metadata `@:native` manualmente o usar llamadas `untyped __gdscript__`, lo cual es tedioso y propenso a errores.
+
+> NOTA: Esta funcionalidad requiere un entorno de Haxe → GDScript. Podría funcionar con Haxe → C++ → (godot-cpp), ¡pero no está probado! - Johanna
+
+La opción `--addon` resuelve esto parseando automáticamente archivos `.gd` y generando bindings de Haxe con tipado seguro para addons de GDScript.
+
+### Uso
+
+```bash
+haxelib run godot-api-generator --addon ruta/al/addon/ [directorio-salida]
+```
+
+### Ejemplo
+
+Dado un addon de GDScript en `addons/mi_addon/`:
+
+```gdscript
+# addons/mi_addon/mi_clase.gd
+class_name MiClase extends Node
+
+signal vida_cambio(valor_anterior: int, valor_nuevo: int)
+
+var vida: int = 100
+@export var vida_maxima: int = 100
+
+func recibir_danio(cantidad: int) -> void:
+    vida -= cantidad
+```
+
+Ejecutando:
+
+```bash
+haxelib run godot-api-generator --addon addons/mi_addon/ source/
+```
+
+Genera `source/mi_addon/MiClase.hx`:
+
+```haxe
+package mi_addon;
+
+@:native("MiClase") extern class MiClase extends godot.Node {
+    public function new();
+
+    @:native("vida_cambio") @:signal
+    public var vida_cambio:godot.Signal;
+
+    public var vida:Int;
+    @:export public var vida_maxima:Int;
+
+    @:native("recibir_danio")
+    public function recibir_danio(cantidad:Int):Void;
+}
+```
+
+Ahora puedes usar el addon con tipado seguro:
+
+```haxe
+var miClase = new MiClase();
+miClase.vida_cambio.connect((anterior, nuevo) -> trace('Vida: $anterior -> $nuevo'));
+miClase.recibir_danio(25);
+```
+
+### Qué se Parsea
+
+- Declaraciones `class_name` y `extends`
+- Declaraciones `signal` con argumentos
+- Métodos `func` con argumentos y tipos de retorno
+- Propiedades `var` con tipos
+- Constantes `const`
+- Anotaciones `@export`
+- Declaraciones de funciones multi-línea
+
+### Opciones
+
+Usa con `--nativeName` para usar `@:nativeName` en vez de `@:native`:
+
+```bash
+haxelib run godot-api-generator --nativeName --addon addons/mi_addon/
+```
+
+&nbsp;
+
+## Tabla de Instalación very Epica muy wind ding gaster
+
+Primero instala via git.
+
+```
+haxelib git godot-api-generator https://github.com/SomeRanDev/Haxe-GodotBindingsGenerator
+```
+
+&nbsp;
+
+Luego puedes generar bindings básicos...
+
+```
+haxelib run godot-api-generator [ruta-al-json] [directorio-salida]
+```
+
+&nbsp;
+
+O puedes instalar la librería y crear tu propio generador.
+
+| #   | Qué hacer                                                    | Qué escribir                                                                                                   |
+| --- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Agrega la lib a tu archivo `.hxml` o comando de compilación. | <pre lang="hxml">-lib godot-api-generator</pre>                                                                |
+| 2   | Obtén los `TypeDefinition`s y modifícalos a tu gusto.        | <pre lang="haxe">final haxeTypes: Array&lt;TypeDefinition&gt; = godot.Bindings.generate("ruta-al-json");</pre> |
+| 3   | Genera los bindings a una carpeta.                           | <pre lang="haxe">godot.Bindings.output("carpeta-salida", haxeTypes);</pre>                                     |
+
+&nbsp;
+
+## Datos de Godot-CPP
+
+Si deseas incluir información adicional de bindings de [`godot-cpp`](https://github.com/godotengine/godot-cpp) como `@:include`s y `@:native`s, agrega la flag `--cpp` o la opción `cpp`.
+
+#### Línea de Comandos
+
+```
+haxelib run godot-api-generator [ruta-al-json] [directorio-salida] --cpp
+```
+
+#### Haxe
+
+```haxe
+godot.Bindings.generate("ruta-al-json", { cpp: true });
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Godot Bindings Generator for Haxe
 
-_Generates target-agnostic Godot bindings for Haxe._
+- For Spanish version, see [README.es.md](README.es.md)
+  _Generates target-agnostic Godot bindings for Haxe._
 
-Most Godot binding generators for Haxe are built for a specific Haxe target (Haxe/C++, Haxe/C#, etc.) The goal of this project is to create generic bindings that can work as a *base* for other projects to avoid reinventing the wheel.
+Most Godot binding generators for Haxe are built for a specific Haxe target (Haxe/C++, Haxe/C#, etc.) The goal of this project is to create generic bindings that can work as a _base_ for other projects to avoid reinventing the wheel.
 
 This is achieved by converting Godot's `extension_api.json` data to [`TypeDefinition`](https://api.haxe.org/haxe/macro/TypeDefinition.html) representations of the generated Haxe types. From there, one can manipulate the `TypeDefinition`s to work best for their desired Haxe target. This project will then take care of generating the `.hx` files.
 
@@ -10,9 +11,94 @@ If you just want un-modified, basic Godot bindings, you can do that too!
 
 &nbsp;
 
+## GDScript Addon Bindings
+
+When working with Haxe in Godot, you often need to interact with GDScript-based addons (like dialogue systems, state machines, etc.). Normally this requires manually writing `@:native` metadata or using `untyped __gdscript__` calls, which is tedious and error-prone.
+
+> NOTE: This feature requires an enviroment of Haxe → GDScript, maybe using Haxe → C++ → (godot-cpp) may work, but is untested!!! - Johanna
+
+The `--addon` option solves this by automatically parsing `.gd` files and generating type-safe Haxe bindings for GDScript addons.
+
+### Usage
+
+```bash
+haxelib run godot-api-generator --addon path/to/addon/ [output-dir]
+```
+
+### Example
+
+Given a GDScript addon at `addons/my_addon/`:
+
+```gdscript
+# addons/my_addon/my_class.gd
+class_name MyClass extends Node
+
+signal health_changed(old_value: int, new_value: int)
+
+var health: int = 100
+@export var max_health: int = 100
+
+func take_damage(amount: int) -> void:
+    health -= amount
+```
+
+Running:
+
+```bash
+haxelib run godot-api-generator --addon addons/my_addon/ source/
+```
+
+Generates `source/my_addon/MyClass.hx`:
+
+```haxe
+package my_addon;
+
+@:native("MyClass") extern class MyClass extends godot.Node {
+    public function new();
+
+    @:native("health_changed") @:signal
+    public var health_changed:godot.Signal;
+
+    public var health:Int;
+    @:export public var max_health:Int;
+
+    @:native("take_damage")
+    public function take_damage(amount:Int):Void;
+}
+```
+
+Now you can use the addon with full type safety:
+
+```haxe
+var myClass = new MyClass();
+myClass.health_changed.connect((old, new) -> trace('Health: $old -> $new'));
+myClass.take_damage(25);
+```
+
+### What Gets Parsed
+
+- `class_name` and `extends` declarations
+- `signal` declarations with arguments
+- `func` methods with arguments and return types
+- `var` properties with types
+- `const` constants
+- `@export` annotations
+- Multi-line function declarations
+
+### Options
+
+Use with `--nativeName` to use `@:nativeName` instead of `@:native`:
+
+```bash
+haxelib run godot-api-generator --nativeName --addon addons/my_addon/
+```
+
+&nbsp;
+
 ## Installation Table of Epicness
 
 First install via git.
+
 ```
 haxelib git godot-api-generator https://github.com/SomeRanDev/Haxe-GodotBindingsGenerator
 ```
@@ -20,6 +106,7 @@ haxelib git godot-api-generator https://github.com/SomeRanDev/Haxe-GodotBindings
 &nbsp;
 
 Next you can either generate basic bindings...
+
 ```
 haxelib run godot-api-generator [path-to-json] [output-dir]
 ```
@@ -28,11 +115,11 @@ haxelib run godot-api-generator [path-to-json] [output-dir]
 
 Or you can install the library and create your own generator.
 
-| # | What to do | What to write |
-| - | ------ | ------ |
-| 1 | Add the lib to your `.hxml` file or compile command. | <pre lang="hxml">-lib godot-api-generator</pre> |
-| 2 | Get the `TypeDefinition`s and modify to your liking. | <pre lang="haxe">final haxeTypes: Array&lt;TypeDefinition&gt; = godot.Bindings.generate("path-to-json");</pre> |
-| 3 | Output the bindings to a folder. | <pre lang="haxe">godot.Bindings.output("output-folder", haxeTypes);</pre> |
+| #   | What to do                                           | What to write                                                                                                  |
+| --- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Add the lib to your `.hxml` file or compile command. | <pre lang="hxml">-lib godot-api-generator</pre>                                                                |
+| 2   | Get the `TypeDefinition`s and modify to your liking. | <pre lang="haxe">final haxeTypes: Array&lt;TypeDefinition&gt; = godot.Bindings.generate("path-to-json");</pre> |
+| 3   | Output the bindings to a folder.                     | <pre lang="haxe">godot.Bindings.output("output-folder", haxeTypes);</pre>                                      |
 
 &nbsp;
 
@@ -41,11 +128,13 @@ Or you can install the library and create your own generator.
 If you wish to include additional [`godot-cpp`](https://github.com/godotengine/godot-cpp) binding information such as `@:include`s and `@:native`s, add the `--cpp` flag or `cpp` option.
 
 #### Command Line
+
 ```
 haxelib run godot-api-generator [path-to-json] [output-dir] --cpp
 ```
 
 #### Haxe
+
 ```haxe
 godot.Bindings.generate("path-to-json", { cpp: true });
 ```

--- a/Run.hx
+++ b/Run.hx
@@ -2,198 +2,426 @@ package;
 
 import sys.FileSystem;
 import sys.io.Process;
+import godot.gdscript.GDScriptParser;
+import godot.gdscript.GDScriptBindings;
+
+using StringTools;
 
 function main() {
 	var jsonPath = null;
 	var outputDir = null;
+	var addonPath:Null<String> = null;
 
 	final args = Sys.args();
 
+	// Show help if requested
+	if (args.contains("help") || args.contains("--help") || args.contains("-h")) {
+		help();
+		return;
+	}
+
+	// Print header
+	Sys.println("");
+	Sys.println("╔════════════════════════════════════════════════════╗");
+	Sys.println("║     Godot Bindings Generator for Haxe              ║");
+	Sys.println("║     https://github.com/SomeRanDev/                 ║");
+	Sys.println("║            Haxe-GodotBindingsGenerator             ║");
+	Sys.println("╚════════════════════════════════════════════════════╝");
+	Sys.println("");
+
+	// Parse flags
+	Sys.println("[1/4] Parsing command-line options...");
+
 	// Check for --cpp
-	final isCpp = if(args.contains("--cpp")) {
+	final isCpp = if (args.contains("--cpp")) {
 		args.remove("--cpp");
 		true;
 	} else false;
 
 	// Check for --nativeName
-	final nativeMeta = if(args.contains("--nativeName")) {
+	final nativeMeta = if (args.contains("--nativeName")) {
 		args.remove("--nativeName");
 		":nativeName";
 	} else ":native";
 
 	// Check for --godotVariantType
-	final variantType = if(args.contains("--godotVariantType")) {
+	final variantType = if (args.contains("--godotVariantType")) {
 		args.remove("--godotVariantType");
-		macro : GodotVariant;
-	} else macro : Dynamic;
+		macro :GodotVariant;
+	} else macro :Dynamic;
 
 	// Check for --useGodotTypedArray
-	final typedArrayType = if(args.contains("--useGodotTypedArray")) {
+	final typedArrayType = if (args.contains("--useGodotTypedArray")) {
 		args.remove("--useGodotTypedArray");
-		{ pack: [], name: "GodotTypedArray" }
-	} else ({ pack: [], name: "Array" });
+		{pack: [], name: "GodotTypedArray"}
+	} else ({pack: [], name: "Array"});
 
-	final cwd = switch(args) {
-		case ["help", _]: {
-			help();
-			return;
-		}
-		case [cwd]: {
-			cwd;
-		}
-		case [_outputDir, cwd]: {
-			outputDir = _outputDir;
-			cwd;
-		}
-		case [_outputDir, _jsonPath, cwd]: {
-			outputDir = _outputDir;
-			jsonPath = _jsonPath;
-			cwd;
-		}
-		case _: {
-			Sys.println("** Invalid arguments. **\n");
-			help();
-			return;
+	// Check for --addon <path>
+	if (args.contains("--addon")) {
+		final idx = args.indexOf("--addon");
+		args.remove("--addon");
+		if (idx < args.length) {
+			addonPath = args[idx];
+			args.splice(idx, 1);
 		}
 	}
 
-	// Ensure we use current directory of haxelib run call.
-	if(cwd != null) {
+	final cwd = switch (args) {
+		case [cwd]: {
+				cwd;
+			}
+		case [_outputDir, cwd]: {
+				outputDir = _outputDir;
+				cwd;
+			}
+		case [_outputDir, _jsonPath, cwd]: {
+				outputDir = _outputDir;
+				jsonPath = _jsonPath;
+				cwd;
+			}
+		case _: {
+				Sys.println("");
+				Sys.println("ERROR: Invalid arguments provided.");
+				Sys.println("");
+				help();
+				return;
+			}
+	}
+
+	// Print active configuration
+	Sys.println("");
+	Sys.println("  Active Configuration:");
+	Sys.println("  ─────────────────────────────────────────────────");
+	Sys.println('  • C++ mode:            ${isCpp ? "ENABLED" : "disabled"}');
+	Sys.println('  • Native meta:         ${nativeMeta}');
+	Sys.println('  • Variant type:        ${isCpp ? "GodotVariant" : "Dynamic"}');
+	Sys.println('  • TypedArray type:     ${typedArrayType.name}');
+	if (addonPath != null) {
+		Sys.println('  • Addon mode:          ENABLED');
+		Sys.println('  • Addon path:          ${addonPath}');
+	}
+	Sys.println("  ─────────────────────────────────────────────────");
+	Sys.println("");
+
+	// Ensure we use current directory of haxelib run call
+	if (cwd != null) {
 		Sys.setCwd(cwd);
 	}
 
 	// Check output directory
-	if(outputDir == null) {
-		Sys.println("No output directory defined, using \"godot/\".");
+	if (outputDir == null) {
 		outputDir = "godot";
+		Sys.println('  → Output directory not specified, using default: "$outputDir/"');
+	} else {
+		Sys.println('  → Output directory: "$outputDir/"');
 	}
 
+	// ═══════════════════════════════════════════════════════════════════
+	// ADDON MODE: Generate bindings from GDScript files
+	// ═══════════════════════════════════════════════════════════════════
+	if (addonPath != null) {
+		generateAddonBindings(addonPath, outputDir, nativeMeta);
+		return;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════
+	// GODOT API MODE: Generate bindings from extension_api.json
+	// ═══════════════════════════════════════════════════════════════════
+
 	// Check json path
-	final shouldGenerate = if(jsonPath == null && !FileSystem.exists("extension_api.json")) {
-		Sys.println("No `extension_api.json` found, let's generated them!");
+	Sys.println("");
+	Sys.println("[2/4] Locating extension_api.json...");
+
+	final shouldGenerate = if (jsonPath == null && !FileSystem.exists("extension_api.json")) {
+		Sys.println("  → No extension_api.json found in current directory.");
+		Sys.println("  → Will generate it automatically using Godot.");
 		true;
 	} else {
-		if(jsonPath == null) {
+		if (jsonPath == null) {
 			jsonPath = "extension_api.json";
 		}
+		Sys.println('  → Using: "$jsonPath"');
 		false;
 	}
 
-	// Generate extension_api.json
-	if(shouldGenerate) {
+	// Generate extension_api.json if needed
+	if (shouldGenerate) {
+		Sys.println("");
 		jsonPath = "extension_api.json";
 		generateJson();
 	}
 
-	if(jsonPath == null) {
-		Sys.println("extension_api.json path not found; aborting.");
+	if (jsonPath == null) {
+		Sys.println("");
+		Sys.println("ERROR: extension_api.json path not found. Aborting.");
+		Sys.println("");
+		Sys.println("HINT: You can generate this file manually by running:");
+		Sys.println("      godot --dump-extension-api-with-docs --headless");
+		return;
 	}
 
 	// Generate and output type definitions
+	Sys.println("");
+	Sys.println("[3/4] Generating Haxe type definitions...");
+	Sys.println('  → Reading API from: "$jsonPath"');
+
 	final typeDefinitions = godot.Bindings.generate(jsonPath, {
 		cpp: isCpp,
 		nativeNameMeta: nativeMeta,
 		godotVariantType: variantType,
 		typedArrayType: typedArrayType
 	});
+
+	Sys.println('  → Generated ${typeDefinitions.length} type definitions.');
+
+	Sys.println("");
+	Sys.println("[4/4] Writing output files...");
+	Sys.println('  → Writing to: "$outputDir/"');
+
 	godot.Bindings.output(outputDir, typeDefinitions);
 
-	// We done!!
-	Sys.println("Done!");
-}
+	Sys.println('  → Wrote ${typeDefinitions.length} files.');
 
-function help() {
-	Sys.println("====================================
-* Godot Bindings Generator for Haxe
-====================================
-godot-api-generator [output-directory=godot_bindings] [json-path] 
-
-If no \"json-path\" is given, the bindings will be generated automatically.
-
-[Print this help message]
-godot-api-generator help
-
-[Add C++ Information]
---cpp
-====================================");
+	// Success!
+	Sys.println("");
+	Sys.println("╔════════════════════════════════════════════════════╗");
+	Sys.println("║  ✓ Generation complete!                            ║");
+	Sys.println("╚════════════════════════════════════════════════════╝");
+	Sys.println("");
+	Sys.println('Add "-cp $outputDir" to your .hxml file to use the bindings.');
+	Sys.println("");
 }
 
 /**
-	Generates the `extension_api.json` file by asking for Godot path.
+	Generates Haxe bindings from GDScript addon files.
+**/
+function generateAddonBindings(addonPath:String, outputDir:String, nativeMeta:String) {
+	Sys.println("");
+	Sys.println("[2/3] Scanning GDScript files...");
+
+	if (!FileSystem.exists(addonPath)) {
+		Sys.println("");
+		Sys.println('  ERROR: Addon path "$addonPath" does not exist.');
+		return;
+	}
+
+	Sys.println('  → Scanning: "$addonPath"');
+
+	final classes = GDScriptParser.parseDirectory(addonPath);
+
+	if (classes.length == 0) {
+		Sys.println("");
+		Sys.println("  WARNING: No GDScript classes with 'class_name' found.");
+		Sys.println("  → Only scripts with 'class_name' declaration are processed.");
+		Sys.println("  → Anonymous scripts (without class_name) are skipped.");
+		return;
+	}
+
+	Sys.println('  → Found ${classes.length} class(es):');
+	for (cls in classes) {
+		final methodCount = cls.methods.length;
+		final propCount = cls.properties.length;
+		final signalCount = cls.signals.length;
+		Sys.println('      • ${cls.name} (${methodCount} methods, ${propCount} properties, ${signalCount} signals)');
+	}
+
+	Sys.println("");
+	Sys.println("[3/3] Generating Haxe type definitions...");
+
+	// Set the native name metadata
+	GDScriptBindings.nativeNameMeta = nativeMeta;
+
+	// Determine package name from addon path (use last folder name)
+	final normalizedPath = addonPath.replace("\\", "/");
+	final pathParts = normalizedPath.split("/").filter(p -> p.length > 0);
+	final basePackage = if (pathParts.length > 0) {
+		// Use the last folder name as package, sanitized
+		final lastPart = pathParts[pathParts.length - 1];
+		StringTools.replace(lastPart, "-", "_").toLowerCase();
+	} else {
+		"addon";
+	};
+
+	Sys.println('  → Package: $basePackage');
+
+	final typeDefinitions = GDScriptBindings.generateFromClasses(classes, basePackage);
+
+	Sys.println('  → Generated ${typeDefinitions.length} type definition(s).');
+
+	Sys.println('  → Writing to: "$outputDir/$basePackage/"');
+
+	godot.Bindings.output(outputDir, typeDefinitions);
+
+	Sys.println('  → Wrote ${typeDefinitions.length} file(s).');
+
+	// Success!
+	Sys.println("");
+	Sys.println("╔════════════════════════════════════════════════════╗");
+	Sys.println("║  ✓ Addon bindings generated!                       ║");
+	Sys.println("╚════════════════════════════════════════════════════╝");
+	Sys.println("");
+	Sys.println('Add "-cp $outputDir" to your .hxml file to use the addon bindings.');
+	Sys.println('Import classes with: import $basePackage.ClassName;');
+	Sys.println("");
+}
+
+function help() {
+	Sys.println("
+╔════════════════════════════════════════════════════════════════════════╗
+║                  Godot Bindings Generator for Haxe                     ║
+╚════════════════════════════════════════════════════════════════════════╝
+
+USAGE:
+  haxelib run godot-api-generator [OPTIONS] [OUTPUT_DIR] [JSON_PATH]
+
+ARGUMENTS:
+  OUTPUT_DIR    Directory where Haxe files will be generated.
+                Default: \"godot/\"
+
+  JSON_PATH     Path to Godot's extension_api.json file.
+                If not provided and file doesn't exist, it will be
+                generated automatically (requires Godot in PATH or
+                GODOT_PATH environment variable).
+
+OPTIONS:
+  --cpp                  Enable C++ mode. Adds @:include metadata for
+                         godot-cpp headers and wraps types with Ref<T>
+                         and pointer types where appropriate.
+
+  --nativeName           Use @:nativeName instead of @:native for
+                         field renaming metadata.
+
+  --godotVariantType     Use 'GodotVariant' type instead of 'Dynamic'
+                         for Godot's Variant type.
+
+  --useGodotTypedArray   Use 'GodotTypedArray<T>' instead of 'Array<T>'
+                         for typed arrays.
+
+  --addon <PATH>         Generate Haxe bindings from GDScript addon files.
+                         Parses .gd files in the given directory and generates
+                         type definitions for classes with 'class_name'.
+                         Extracts: signals, methods, properties, constants.
+
+  help, --help, -h       Show this help message.
+
+EXAMPLES:
+  # Basic usage (auto-detect extension_api.json)
+  haxelib run godot-api-generator
+
+  # Specify output directory
+  haxelib run godot-api-generator my_bindings/
+
+  # Specify both output and json path
+  haxelib run godot-api-generator bindings/ path/to/extension_api.json
+
+  # Enable C++ mode
+  haxelib run godot-api-generator --cpp
+
+  # Full example with all options
+  haxelib run godot-api-generator --cpp --nativeName --godotVariantType bindings/
+
+  # Generate bindings from a GDScript addon
+  haxelib run godot-api-generator --addon addons/my_addon/ addon_bindings/
+
+  # Generate from addon with default output directory
+  haxelib run godot-api-generator --addon path/to/addon/
+
+ENVIRONMENT VARIABLES:
+  GODOT_PATH    Path to Godot executable (used when generating
+                extension_api.json automatically).
+
+MORE INFO:
+  https://github.com/SomeRanDev/Haxe-GodotBindingsGenerator
+");
+}
+
+/**
+	Generates the `extension_api.json` file by locating or asking for Godot path.
 **/
 function generateJson() {
-	// We start!!
-	Sys.println("Generating Godot bindings...");
+	Sys.println("[2/4] Auto-generating extension_api.json...");
 
 	// Check for godot executable
 	var godotVersion = "";
-	var godotPath: Null<String> = Sys.getEnv("GODOT_PATH");
-	if(godotPath == null) {
+	var godotPath:Null<String> = Sys.getEnv("GODOT_PATH");
+
+	if (godotPath != null) {
+		Sys.println('  → Found GODOT_PATH environment variable: "$godotPath"');
+	}
+
+	if (godotPath == null) {
+		Sys.println("  → Checking if 'godot' is available in PATH...");
 		godotPath = try {
 			final process = new Process("godot", ["--version"]);
-			if(process.exitCode(true) == 0) {
+			if (process.exitCode(true) == 0) {
+				godotVersion = process.stdout.readAll().toString().split("\n")[0];
+				Sys.println('  → Found Godot in PATH (version: $godotVersion)');
 				"godot";
 			} else {
 				null;
 			}
-		} catch(e) {
+		} catch (e) {
 			null;
 		}
 	}
 
 	// Request path to godot executable if not found
-	if(godotPath == null) {
-		Sys.println("'godot' could not be found, please enter the path to the executable:");
-		Sys.print("> ");
+	if (godotPath == null) {
+		Sys.println("");
+		Sys.println("  ┌─────────────────────────────────────────────────────────┐");
+		Sys.println("  │  Godot executable not found!                            │");
+		Sys.println("  │                                                         │");
+		Sys.println("  │  Please enter the full path to your Godot executable:   │");
+		Sys.println("  │  (e.g., C:\\Godot\\godot.exe or /usr/bin/godot)           │");
+		Sys.println("  └─────────────────────────────────────────────────────────┘");
+		Sys.println("");
+		Sys.print("  Path> ");
 
-		while(true) {
+		while (true) {
 			final path = Sys.stdin().readLine().toString();
 
-			godotPath = if(FileSystem.exists(path) && !FileSystem.isDirectory(path)) {
-				try {
-					final process = new Process(path, ["--version"]);
-
-					Sys.println(
-"
-NOTE!!!
-Newer versions of Godot hang forever when checking version or generating bindings, breaking compatibility with this tool. If things freeze and don't continue, that means you need to generate the `extension_api.json` file manually by running:
-
-godot.exe --dump-extension-api-with-docs
-
-Otherwise, this file should generate automatically in a couple seconds...
-"
-					);
-
-					if(process.exitCode(true) == 0) {
-						godotVersion = process.stdout.readAll().toString();
-						path;
-					} else {
-						null;
-					}
-					
-				} catch(e) {
-					null;
-				}
-			} else {
-				null;
-			}
-
-			if(godotPath == null) {
-				Sys.println("'" + path + "' could not be found, please try again:");
-				Sys.print("> ");
-			} else {
+			if (FileSystem.exists(path) && !FileSystem.isDirectory(path)) {
+				godotPath = path;
+				Sys.println('  → Using: "$path"');
+				Sys.println("  → Skipping version check (assuming Godot 4.2+)");
 				break;
+			} else {
+				Sys.println('  → ERROR: Could not find "$path"');
+				Sys.println("  → Please try again:");
+				Sys.print("  Path> ");
 			}
 		}
 	}
 
+	// Determine which dump command to use based on version
+	// Default to newer format (4.2+) since most users will have recent Godot
 	final versionArray = godotVersion.split(".");
-	final is4_2orAbove = Std.parseInt(versionArray[0]) >= 4 && Std.parseInt(versionArray[1]) >= 2;
+	final majorVersion = Std.parseInt(versionArray[0]) ?? 4;
+	final minorVersion = Std.parseInt(versionArray[1]) ?? 2;
+	final is4_2orAbove = majorVersion >= 4 && minorVersion >= 2;
 
+	// Always use --dump-extension-api-with-docs for 4.2+, otherwise fall back
 	final dumpType = is4_2orAbove ? "--dump-extension-api-with-docs" : "--dump-extension-api";
 
-	// Generate `extension_api.json`
-	Sys.println('>> ${godotPath} ${dumpType} --headless');
-	final process = new Process(godotPath, [dumpType, "--headless"]);
-	process.exitCode(true);
+	Sys.println("");
+	Sys.println("  → Running Godot to generate extension_api.json...");
+	Sys.println('  → Command: $godotPath $dumpType --headless');
+	Sys.println("");
+	Sys.println("  (This may take a few seconds...)");
+	Sys.println("");
+
+	// Generate `extension_api.json` using Sys.command for better compatibility
+	final exitCode = Sys.command('"$godotPath" $dumpType --headless');
+
+	if (exitCode == 0 && FileSystem.exists("extension_api.json")) {
+		Sys.println("  → extension_api.json generated successfully!");
+	} else {
+		Sys.println("");
+		Sys.println("  ┌─────────────────────────────────────────────────────────┐");
+		Sys.println("  │  WARNING: Godot may not have generated the file.        │");
+		Sys.println("  │                                                         │");
+		Sys.println("  │  If extension_api.json was not created, run manually:   │");
+		Sys.println("  │    godot --dump-extension-api-with-docs --headless      │");
+		Sys.println("  └─────────────────────────────────────────────────────────┘");
+	}
 }

--- a/TODO.md
+++ b/TODO.md
@@ -14,4 +14,5 @@
 - Test with complex addons
 - Test with CPP
 - Makes sure all types are covered
+- GET/SET methods (like `get_foo`/`set_foo`) should be converted to properties I DONT KNOW IF THIS WORKS, SO THIS SHOULD BE HERE? :susieWorry:
 - Refactor to use AST nodes

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,17 @@
-* ~~Multiple constructors with @:overload~~
-* Signals
-* Cleanup
+## Godot Bindings Generator - TODO
+
+- ~~Multiple constructors with @:overload~~
+- ~~Signals~~
+- Cleanup
+
+## GDScript Bindings - TODO
+
+- ~~Basic class parsing~~
+- ~~Properties (exported and regular)~~
+- ~~Methods~~
+- ~~Signals~~
+- ~~Inheritance~~
+- Test with complex addons
+- Test with CPP
+- Makes sure all types are covered
+- Refactor to use AST nodes

--- a/src/godot/Bindings.hx
+++ b/src/godot/Bindings.hx
@@ -2,23 +2,18 @@ package godot;
 
 import godot.extension_api.BuiltinClass;
 import godot.BindingsUtil as Util;
-
 import godot.bindings.Options;
-
 import godot.extension_api.Class as GodotClass;
 import godot.extension_api.GlobalConstant;
 import godot.extension_api.Enums.GlobalOrClassEnum;
 import godot.extension_api.UtilityFunction;
-
 import godot.generation.GenerateBuiltinClass;
 import godot.generation.GenerateClass;
 import godot.generation.GenerateEnum;
 import godot.generation.GenerateUtilityFunction;
 import godot.generation.GenerateGlobalConstant;
-
 import haxe.Json;
 import haxe.io.Path;
-
 import haxe.macro.ComplexTypeTools;
 import haxe.macro.Context;
 import haxe.macro.Expr;
@@ -27,14 +22,11 @@ import haxe.macro.Expr.AbstractFlag;
 #end
 import haxe.macro.MacroStringTools;
 import godot.haxestd.Printer;
-
 import sys.FileSystem;
 import sys.io.File;
 
 // ---
-
 using StringTools;
-
 using godot.bindings.NullableArrayTools;
 using godot.bindings.NullTools;
 
@@ -53,12 +45,12 @@ class Bindings {
 		Need to store this option statically since cannot access `bindings.Options` from
 		the `output` function.
 	**/
-	static var fileComment: Null<String> = null;
+	static var fileComment:Null<String> = null;
 
 	/**
 		Generates a list of `TypeDefinition`s generated from the `extension_api.json` file.
 	**/
-	public static function generate(extensionJsonPath: String, options: Null<Options> = null): Array<TypeDefinition> {
+	public static function generate(extensionJsonPath:String, options:Null<Options> = null):Array<TypeDefinition> {
 		final bindings = new Bindings(extensionJsonPath, options ?? {});
 		return bindings.make();
 	}
@@ -66,16 +58,27 @@ class Bindings {
 	/**
 		Outputs `TypeDefinition`s as Haxe source files.
 	**/
-	public static function output(outputPath: String, typeDefinitions: Array<TypeDefinition>) {
-		if(!FileSystem.exists(outputPath)) {
+	public static function output(outputPath:String, typeDefinitions:Array<TypeDefinition>) {
+		if (!FileSystem.exists(outputPath)) {
 			FileSystem.createDirectory(outputPath);
 		}
-  
+
 		final printer = new Printer();
-		for(definition in typeDefinitions) {
-			final p = Path.join([outputPath, definition.name + ".hx"]);
+		for (definition in typeDefinitions) {
+			// Create package subdirectory if needed
+			final packagePath = if (definition.pack != null && definition.pack.length > 0) {
+				final subDir = Path.join([outputPath].concat(definition.pack));
+				if (!FileSystem.exists(subDir)) {
+					createDirectoryRecursive(subDir);
+				}
+				subDir;
+			} else {
+				outputPath;
+			};
+
+			final p = Path.join([packagePath, definition.name + ".hx"]);
 			final content = printer.printTypeDefinition(definition);
-			final prefixContent = if(fileComment != null) {
+			final prefixContent = if (fileComment != null) {
 				'/**\n${fileComment.split("\n").map(s -> "\t" + s).join("\n")}\n**/\n';
 			} else {
 				"";
@@ -85,14 +88,36 @@ class Bindings {
 	}
 
 	/**
+		Creates directories recursively.
+	**/
+	static function createDirectoryRecursive(path:String) {
+		final normalized = path.replace("\\", "/");
+		final parts = normalized.split("/");
+		var current = "";
+		for (i => part in parts) {
+			if (part.length == 0)
+				continue;
+			// Handle Windows drive letter (e.g., "E:")
+			if (i == 0 && part.length == 2 && part.charAt(1) == ":") {
+				current = part;
+				continue;
+			}
+			current = current.length == 0 ? part : current + "/" + part;
+			if (!FileSystem.exists(current)) {
+				FileSystem.createDirectory(current);
+			}
+		}
+	}
+
+	/**
 		Loads the `extension_api.json` data, or throws an error if fails.
 	**/
-	static function loadData(extensionJsonPath: String): ExtensionApi {
-		if(FileSystem.exists(extensionJsonPath)) {
+	static function loadData(extensionJsonPath:String):ExtensionApi {
+		if (FileSystem.exists(extensionJsonPath)) {
 			final content = File.getContent(extensionJsonPath);
 			return try {
 				Json.parse(content);
-			} catch(e) {
+			} catch (e) {
 				throw 'Could not parse ${extensionJsonPath}. ${e}';
 			}
 		}
@@ -102,32 +127,32 @@ class Bindings {
 	/**
 		The `extension_api.json` path.
 	**/
-	var extensionJsonPath: String;
+	var extensionJsonPath:String;
 
 	/**
 		Stored reference to the provided option object.
 	**/
-	var options: Options;
+	var options:Options;
 
 	/**
 		Stores the kind of "Type" a class should be when used as param or return.
 	**/
-	var typeType: Map<String, TypeType>;
+	var typeType:Map<String, TypeType>;
 
 	/**
 		A cache of enums to be referenced later when generating special properties that need them.
 	**/
-	var globalEnums: Map<String, GlobalOrClassEnum> = [];
+	var globalEnums:Map<String, GlobalOrClassEnum> = [];
 
 	/**
 		A cache of builtin-classes to be referenced later when generating special properties that need them.
 	**/
-	var builtinClasses: Map<String, BuiltinClass> = [];
+	var builtinClasses:Map<String, BuiltinClass> = [];
 
 	/**
 		Constructor. Sets up all the fields.
 	**/
-	function new(extensionJsonPath: String, options: Options) {
+	function new(extensionJsonPath:String, options:Options) {
 		this.extensionJsonPath = extensionJsonPath;
 		this.options = options;
 		this.typeType = [];
@@ -135,44 +160,53 @@ class Bindings {
 		Bindings.fileComment = options?.fileComment; // Use this later in `output` static function.
 	}
 
-	static function isPrimitive(typeName: String) {
+	static function isPrimitive(typeName:String) {
 		return [
-			"Nil", "void", "bool", "real_t", "float", "double", "int",
-			"int8_t", "uint8_t", "int16_t", "uint16_t",
-			"int32_t", "int64_t", "uint32_t", "uint64_t",
+			"Nil",
+			"void",
+			"bool",
+			"real_t",
+			"float",
+			"double",
+			"int",
+			"int8_t",
+			"uint8_t",
+			"int16_t",
+			"uint16_t",
+			"int32_t",
+			"int64_t",
+			"uint32_t",
+			"uint64_t",
 		].contains(typeName);
 	}
 
 	/**
 		Generates the `TypeDefinition`s.
 	**/
-	function make(): Array<TypeDefinition> {
+	function make():Array<TypeDefinition> {
 		final data = loadData(extensionJsonPath);
-		final result: Array<TypeDefinition> = [];
+		final result:Array<TypeDefinition> = [];
 
 		// Figure out which classes should be Ref<T> or T*
-		if(options.cpp) {
+		if (options.cpp) {
 			typeType.set("Object", CppPointer);
-			for(cls in data.classes) {
-				if(StringTools.endsWith(cls.name, "*")) {
+			for (cls in data.classes) {
+				if (StringTools.endsWith(cls.name, "*")) {
 					typeType.set(cls.name, None);
 					continue;
 				}
 				typeType.set(cls.name, cls.is_refcounted ? GodotRef : CppPointer);
 			}
 
-			for(builtin in data.builtin_classes) {
+			for (builtin in data.builtin_classes) {
 				typeType.set(builtin.name, isPrimitive(builtin.name) ? Primitive : Builtin);
 			}
 		}
 
 		// Generate bindings for "utility_functions" and "global_constants"
-		result.push(makeClassTypeDefinition("Godot", (
-				data.utility_functions.map(uf -> GenerateUtilityFunction.generate(uf, this)).concat(
-					data.global_constants.map(gc -> GenerateGlobalConstant.generate(gc, this))
-				)
-			)
-		));
+		result.push(makeClassTypeDefinition("Godot",
+			(data.utility_functions.map(uf -> GenerateUtilityFunction.generate(uf, this))
+				.concat(data.global_constants.map(gc -> GenerateGlobalConstant.generate(gc, this))))));
 
 		// Generate bindings for "global_enums"
 		GenerateEnum.generate(data, this, result);
@@ -189,14 +223,14 @@ class Bindings {
 	/**
 		Get the "pack" that should be used by the Godot Haxe binding types.
 	**/
-	public function getPack(): Array<String> {
+	public function getPack():Array<String> {
 		return [options.basePackage];
 	}
 
 	/**
 		Generates a very basic class `TypeDefinition` given a name and list of `Field`s.
 	**/
-	function makeClassTypeDefinition(name: String, fields: Array<Field>): TypeDefinition {
+	function makeClassTypeDefinition(name:String, fields:Array<Field>):TypeDefinition {
 		return {
 			name: name,
 			pack: getPack(),
@@ -210,50 +244,46 @@ class Bindings {
 	/**
 		Converts a `String` of a Godot type to the Haxe `ComplexType` equivalent.
 	**/
-	public function getType(typeString: String, noCppWrap: Bool = false): ComplexType {
+	public function getType(typeString:String, noCppWrap:Bool = false):ComplexType {
 		final typearrPrefix = "typedarray::";
-		if(StringTools.startsWith(typeString, typearrPrefix)) {
+		if (StringTools.startsWith(typeString, typearrPrefix)) {
 			return TPath({
 				pack: options.typedArrayType.pack,
 				name: options.typedArrayType.name,
-				params: [
-					TPType(getType(typeString.substring(typearrPrefix.length)))
-				]
+				params: [TPType(getType(typeString.substring(typearrPrefix.length)))]
 			});
 		}
 
-		if(options.cpp && !noCppWrap && typeType.exists(typeString)) {
-			switch(typeType.get(typeString)) {
-				case GodotRef: {
-					return TPath({
-						pack: options.refType.pack,
-						name: options.refType.name,
-						params: [
-							TPType(TPath({ pack: getPack(), name: typeString }))
-						]
-					});
-				}
-				case CppPointer: {
-					return TPath({
-						pack: options.ptrType.pack,
-						name: options.ptrType.name,
-						params: [
-							TPType(TPath({ pack: getPack(), name: typeString }))
-						]
-					});
-				}
+		if (options.cpp && !noCppWrap && typeType.exists(typeString)) {
+			switch (typeType.get(typeString)) {
+				case GodotRef:
+					{
+						return TPath({
+							pack: options.refType.pack,
+							name: options.refType.name,
+							params: [TPType(TPath({pack: getPack(), name: typeString}))]
+						});
+					}
+				case CppPointer:
+					{
+						return TPath({
+							pack: options.ptrType.pack,
+							name: options.ptrType.name,
+							params: [TPType(TPath({pack: getPack(), name: typeString}))]
+						});
+					}
 				case _:
 			}
 		}
 
-		if(StringTools.startsWith(typeString, "enum::")) {
+		if (StringTools.startsWith(typeString, "enum::")) {
 			final enumTypePath = typeString.substr("enum::".length);
 			final enumPack = enumTypePath.split(".");
 			return TPath({
 				pack: getPack(),
 				name: enumPack.join("_")
 			});
-		} else if(StringTools.startsWith(typeString, "bitfield::")) {
+		} else if (StringTools.startsWith(typeString, "bitfield::")) {
 			final bitfieldTypePath = typeString.substr("bitfield::".length);
 			final bitfieldPack = bitfieldTypePath.split(".");
 			return TPath({
@@ -262,21 +292,21 @@ class Bindings {
 			});
 		}
 
-		return switch(typeString) {
-			case "bool": macro : Bool;
-			case "int": macro : Int;
-			case "float": macro : Float;
-			case "String": macro : String;
+		return switch (typeString) {
+			case "bool": macro :Bool;
+			case "int": macro :Int;
+			case "float": macro :Float;
+			case "String": macro :String;
 			case "Array": return TPath({
-				pack: options.arrayType.pack,
-				name: options.arrayType.name,
-				params: []
-			});
+					pack: options.arrayType.pack,
+					name: options.arrayType.name,
+					params: []
+				});
 			case "Variant": options.godotVariantType;
 			case _: TPath({
-				pack: getPack(),
-				name: typeString
-			});
+					pack: getPack(),
+					name: typeString
+				});
 		}
 	}
 
@@ -284,52 +314,37 @@ class Bindings {
 		The same as `getType`, but can accept `null`.
 		If `null` is passed, `Void` `ComplexType` is returned.
 	**/
-	public function getReturnType(typeString: Null<String>): ComplexType {
-		return typeString == null ? (macro : Void) : getType(typeString);
+	public function getReturnType(typeString:Null<String>):ComplexType {
+		return typeString == null ? (macro :Void) : getType(typeString);
 	}
 
 	/**
 		Compile type for function argument.
 	**/
-	public function getArgumentType(typeString: String): ComplexType {
-		final result = getType(typeString);
-
-		if(options.cpp && typeType.exists(typeString)) {
-			// switch(typeType.get(typeString)) {
-			// 	case GodotRef | Builtin: {
-			// 		return TPath({
-			// 			pack: ["cxx"],
-			// 			name: "ConstRef",
-			// 			params: [ TPType(result) ]
-			// 		});
-			// 	}
-			// 	case _:
-			// }
-		}
-
-		return result;
+	public function getArgumentType(typeString:String):ComplexType {
+		return getType(typeString);
 	}
 
 	/**
 		Given a Godot argument JSON object (with "default_value" and "type" Strings),
 		returns the default value expression for Haxe or null.
 	**/
-	public function getValue(data: { default_value: Null<String>, type: String }): Null<Expr> {
-		if(data.default_value == null) {
+	public function getValue(data:{default_value:Null<String>, type:String}):Null<Expr> {
+		if (data.default_value == null) {
 			return null;
 		}
 
-		if(data.default_value == "null") {
+		if (data.default_value == "null") {
 			return macro null;
 		}
 
-		if(data.type.startsWith("enum::")) {
+		if (data.type.startsWith("enum::")) {
 			final key = data.type.substr("enum::".length).replace(".", "_");
 			final caseIndex = Std.parseInt(data.default_value);
 			final enumData = globalEnums[key];
-			if(enumData != null) {
-				for(v in enumData.values) {
-					if(v.value == caseIndex) {
+			if (enumData != null) {
+				for (v in enumData.values) {
+					if (v.value == caseIndex) {
 						final fields = ComplexTypeTools.toString(getType(data.type)).split(".");
 						fields.push(v.name);
 						final chainFields = MacroStringTools.toFieldExpr(fields);
@@ -339,7 +354,7 @@ class Bindings {
 			}
 		}
 
-		final v: Dynamic = switch(data.type) {
+		final v:Dynamic = switch (data.type) {
 			case "bool": data.default_value == "true";
 			case "int": Std.parseInt(data.default_value);
 			case "float": Std.parseFloat(data.default_value);
@@ -354,30 +369,30 @@ class Bindings {
 		Given a Godot argument JSON object (with "default_value" and "type" Strings),
 		returns the default value expression for Haxe or null.
 	**/
-	public function getValueAsGDScript(data: { default_value: Null<String>, type: String }): Null<String> {
-		if(data.default_value == null) {
+	public function getValueAsGDScript(data:{default_value:Null<String>, type:String}):Null<String> {
+		if (data.default_value == null) {
 			return null;
 		}
 
-		if(data.default_value == "null") {
+		if (data.default_value == "null") {
 			return null;
 		}
 
-		if(data.type.startsWith("enum::")) {
+		if (data.type.startsWith("enum::")) {
 			final enumName = data.type.substr("enum::".length);
 			final key = enumName.replace(".", "_");
 			final caseIndex = Std.parseInt(data.default_value);
 			final enumData = globalEnums[key];
-			if(enumData != null) {
-				for(v in enumData.values) {
-					if(v.value == caseIndex) {
+			if (enumData != null) {
+				for (v in enumData.values) {
+					if (v.value == caseIndex) {
 						return enumName + "." + v.name;
 					}
 				}
 			}
 		}
 
-		return switch(data.type) {
+		return switch (data.type) {
 			case "bool" | "int" | "float" | "String": data.default_value;
 			case _: return null;
 		}

--- a/src/godot/gdscript/GDScriptBindings.hx
+++ b/src/godot/gdscript/GDScriptBindings.hx
@@ -1,0 +1,278 @@
+package godot.gdscript;
+
+import haxe.macro.Expr;
+import godot.BindingsUtil as Util;
+import godot.gdscript.GDScriptParser;
+
+using StringTools;
+
+/**
+ *  Generates Haxe TypeDefinitions from parsed GDScript classes. 
+ * 
+ *  @author Elizabeth "Niz" Johana - 2026 
+ */
+class GDScriptBindings {
+	/**
+		Native name metadata to use (can be `:native` or `:nativeName`).
+	**/
+	public static var nativeNameMeta:String = ":native";
+
+	/**
+		Generate Haxe type definitions from a directory of GDScript files.
+	**/
+	public static function generateFromDirectory(path:String, basePackage:String = "addon"):Array<TypeDefinition> {
+		final classes = GDScriptParser.parseDirectory(path);
+		return generateFromClasses(classes, basePackage);
+	}
+
+	/**
+		Generate Haxe type definitions from parsed GDScript classes.
+	**/
+	public static function generateFromClasses(classes:Array<GDScriptClass>, basePackage:String):Array<TypeDefinition> {
+		final result:Array<TypeDefinition> = [];
+
+		for (cls in classes) {
+			result.push(generateClass(cls, basePackage));
+		}
+
+		return result;
+	}
+
+	static function generateClass(cls:GDScriptClass, basePackage:String):TypeDefinition {
+		final fields:Array<Field> = [];
+		final fieldAccess = [APublic];
+
+		// -- CONSTRUCTORS --
+		fields.push({
+			name: "new",
+			pos: Util.makeEmptyPosition(),
+			access: fieldAccess,
+			kind: FFun({args: []}),
+			meta: []
+		});
+
+		// -- Constants --
+		for (constant in cls.constants) {
+			final constMeta:Metadata = [];
+			final haxeName = Util.processTypeName(constant.name);
+			if (haxeName != constant.name) {
+				constMeta.push(makeNativeNameMeta(constant.name));
+			}
+
+			fields.push({
+				name: haxeName,
+				pos: Util.makeEmptyPosition(),
+				access: fieldAccess.concat([AStatic]),
+				kind: FVar(constant.type != null ? gdTypeToHaxe(constant.type) : macro :Dynamic, null),
+				meta: constMeta,
+				doc: constant.description
+			});
+		}
+
+		// -- Properties --
+		for (prop in cls.properties) {
+			final propType = prop.type != null ? gdTypeToHaxe(prop.type) : macro :Dynamic;
+
+			final propMeta:Metadata = [];
+
+			final haxeName = Util.processTypeName(prop.name);
+			if (haxeName != prop.name) {
+				propMeta.push(makeNativeNameMeta(prop.name));
+			}
+
+			if (prop.isExport) {
+				propMeta.push({
+					name: ":export",
+					pos: Util.makeEmptyPosition(),
+					params: []
+				});
+			}
+
+			fields.push({
+				name: haxeName,
+				pos: Util.makeEmptyPosition(),
+				access: fieldAccess,
+				kind: FVar(propType),
+				meta: propMeta,
+				doc: prop.description
+			});
+		}
+
+		// -- Signals --
+		for (signal in cls.signals) {
+			var docString = signal.description ?? "";
+			if (signal.arguments.length > 0) {
+				final argsDoc = signal.arguments.map(arg -> {
+					final typeStr = arg.type != null ? ': ${arg.type}' : "";
+					return '${arg.name}$typeStr';
+				}).join(", ");
+				docString = 'Signal arguments: ($argsDoc)\n\n$docString';
+			}
+
+			// Process signal name for Haxe compatibility (maybe rename)
+			final haxeName = Util.processTypeName(signal.name);
+
+			final signalMeta:Metadata = [
+				{
+					name: ":signal",
+					pos: Util.makeEmptyPosition(),
+					params: []
+				},
+				makeNativeNameMeta(signal.name)
+			];
+
+			// Add argument metadata !!
+			for (i => arg in signal.arguments) {
+				signalMeta.push({
+					name: ":signal_arg",
+					pos: Util.makeEmptyPosition(),
+					params: [
+						{expr: EConst(CInt(Std.string(i))), pos: Util.makeEmptyPosition()},
+						{expr: EConst(CString(arg.name)), pos: Util.makeEmptyPosition()},
+						{expr: EConst(CString(arg.type ?? "Variant")), pos: Util.makeEmptyPosition()}
+					]
+				});
+			}
+
+			fields.push({
+				name: haxeName,
+				pos: Util.makeEmptyPosition(),
+				access: fieldAccess,
+				kind: FVar(TPath({
+					pack: ["godot"],
+					name: "Signal",
+					params: null,
+					sub: null
+				})),
+				meta: signalMeta,
+				doc: Util.processDescription(docString)
+			});
+		}
+
+		// Methods
+		for (method in cls.methods) {
+			final args:Array<FunctionArg> = method.arguments.map(arg -> {
+				return {
+					name: Util.processIdentifier(arg.name),
+					type: arg.type != null ? gdTypeToHaxe(arg.type) : macro :Dynamic,
+					opt: arg.defaultValue != null,
+					value: null,
+					meta: null
+				};
+			});
+
+			final haxeName = Util.processTypeName(method.name);
+
+			final methodMeta:Metadata = [makeNativeNameMeta(method.name)];
+
+			final access = method.isStatic ? fieldAccess.concat([AStatic]) : fieldAccess;
+
+			fields.push({
+				name: haxeName,
+				pos: Util.makeEmptyPosition(),
+				access: access,
+				kind: FFun({
+					args: args,
+					ret: method.returnType != null ? gdTypeToHaxe(method.returnType) : macro :Void,
+					expr: null
+				}),
+				meta: methodMeta,
+				doc: method.description
+			});
+		}
+
+		// Build class metadata
+		final meta:Metadata = [
+			{
+				name: ":generated_godot_addon",
+				pos: Util.makeEmptyPosition(),
+				params: []
+			},
+			makeNativeNameMeta(cls.name),
+			{
+				name: ":gdscript_path",
+				pos: Util.makeEmptyPosition(),
+				params: [{expr: EConst(CString(cls.filePath)), pos: Util.makeEmptyPosition()}]
+			}
+		];
+
+		// Determine parent class
+		final parentType = if (cls.extends_ != null) {
+			Util.getTypePathFromComplex(makeGodotType(cls.extends_));
+		} else {
+			null;
+		};
+
+		return {
+			name: Util.processTypeName(cls.name),
+			pack: [basePackage],
+			pos: Util.makeEmptyPosition(),
+			fields: fields,
+			kind: TDClass(parentType, null, false, false, false),
+			isExtern: true,
+			meta: meta,
+			doc: 'GDScript class from: ${cls.filePath}'
+		};
+	}
+
+	/**
+		Creates a native name metadata entry.
+	**/
+	static function makeNativeNameMeta(name:String):MetadataEntry {
+		return {
+			name: nativeNameMeta,
+			pos: Util.makeEmptyPosition(),
+			params: [{expr: EConst(CString(name)), pos: Util.makeEmptyPosition()}]
+		};
+	}
+
+	/**
+		Convert GDScript type to Haxe ComplexType.
+	**/
+	static function gdTypeToHaxe(gdType:String):ComplexType {
+		final trimmed = gdType.trim();
+
+		// Handle typed arrays: Array[String] -> Array<String>
+		if (trimmed.indexOf("[") != -1 && trimmed.indexOf("]") != -1) {
+			final bracketStart = trimmed.indexOf("[");
+			final bracketEnd = trimmed.lastIndexOf("]");
+			final baseType = trimmed.substr(0, bracketStart);
+			final innerType = trimmed.substring(bracketStart + 1, bracketEnd);
+
+			if (baseType == "Array") {
+				// Convert inner type recursively
+				final innerHaxeType = gdTypeToHaxe(innerType);
+				return TPath({
+					pack: [],
+					name: "Array",
+					params: [TPType(innerHaxeType)],
+					sub: null
+				});
+			}
+		}
+
+		return switch (trimmed) {
+			case "int": macro :Int;
+			case "float": macro :Float;
+			case "bool": macro :Bool;
+			case "String" | "StringName": macro :String;
+			case "void": macro :Void;
+			case "Array": macro :Array<Dynamic>;
+			case "Dictionary": macro :Dynamic;
+			case "Variant": macro :Dynamic;
+			case "Error": macro :Int; // GDScript Error is an enum/int
+			case _:
+				// Assume it's a Godot type or class
+				makeGodotType(trimmed);
+		};
+	}
+
+	static function makeGodotType(name:String):ComplexType {
+		return TPath({
+			pack: ["godot"],
+			name: name,
+			params: null,
+			sub: null
+		});
+	}
+}

--- a/src/godot/gdscript/GDScriptParser.hx
+++ b/src/godot/gdscript/GDScriptParser.hx
@@ -1,0 +1,525 @@
+package godot.gdscript;
+
+import sys.FileSystem;
+import sys.io.File;
+
+using StringTools;
+
+/**
+	Parsed GDScript class information.
+**/
+typedef GDScriptClass = {
+	name:String,
+	extends_:Null<String>,
+	filePath:String,
+	signals:Array<GDScriptSignal>,
+	methods:Array<GDScriptMethod>,
+	properties:Array<GDScriptProperty>,
+	constants:Array<GDScriptConstant>
+}
+
+typedef GDScriptSignal = {
+	name:String,
+	arguments:Array<GDScriptArg>,
+	description:Null<String>
+}
+
+typedef GDScriptMethod = {
+	name:String,
+	arguments:Array<GDScriptArg>,
+	returnType:Null<String>,
+	isStatic:Bool,
+	description:Null<String>
+}
+
+typedef GDScriptArg = {
+	name:String,
+	type:Null<String>,
+	defaultValue:Null<String>
+}
+
+typedef GDScriptProperty = {
+	name:String,
+	type:Null<String>,
+	defaultValue:Null<String>,
+	isExport:Bool,
+	isConst:Bool,
+	description:Null<String>
+}
+
+typedef GDScriptConstant = {
+	name:String,
+	type:Null<String>,
+	value:Null<String>,
+	description:Null<String>
+}
+
+/**
+	Simple GDScript parser to extract class information from .gd files.
+**/
+class GDScriptParser {
+	/**
+		Parse all .gd files in a directory recursively.
+	**/
+	public static function parseDirectory(path:String):Array<GDScriptClass> {
+		final results:Array<GDScriptClass> = [];
+
+		if (!FileSystem.exists(path)) {
+			throw 'Directory not found: $path';
+		}
+
+		function scanDir(dir:String) {
+			for (entry in FileSystem.readDirectory(dir)) {
+				final fullPath = haxe.io.Path.join([dir, entry]);
+				if (FileSystem.isDirectory(fullPath)) {
+					// Skip hidden directories and common non-source folders
+					if (!entry.startsWith(".") && entry != "addons" && entry != ".godot") {
+						scanDir(fullPath);
+					}
+				} else if (entry.endsWith(".gd")) {
+					final parsed = parseFile(fullPath);
+					if (parsed != null) {
+						results.push(parsed);
+					}
+				}
+			}
+		}
+
+		scanDir(path);
+		return results;
+	}
+
+	/**
+		Parse a single .gd file.
+	**/
+	public static function parseFile(filePath:String):Null<GDScriptClass> {
+		if (!FileSystem.exists(filePath)) {
+			return null;
+		}
+
+		final content = File.getContent(filePath);
+		return parseContent(content, filePath);
+	}
+
+	/**
+		Join multi-line function declarations into single lines.
+		GDScript allows function signatures to span multiple lines.
+	**/
+	static function joinMultilineDeclarations(content:String):String {
+		final lines = content.split("\n");
+		final result:Array<String> = [];
+		var pendingLine:Null<String> = null;
+		var openParens = 0;
+
+		for (line in lines) {
+			if (pendingLine != null) {
+				// Continue accumulating until parens are balanced and we find ":"
+				pendingLine += " " + line.trim();
+
+				for (i in 0...line.length) {
+					final c = line.charAt(i);
+					if (c == "(")
+						openParens++;
+					else if (c == ")")
+						openParens--;
+				}
+
+				// Check if declaration is complete (balanced parens and ends with :)
+				if (openParens <= 0 && pendingLine.indexOf(":") != -1) {
+					result.push(pendingLine);
+					pendingLine = null;
+					openParens = 0;
+				}
+			} else {
+				final trimmed = line.trim();
+				// Check if this is a func declaration that might span multiple lines
+				if ((trimmed.startsWith("func ") || trimmed.startsWith("static func "))
+					&& trimmed.indexOf("(") != -1
+					&& !trimmed.endsWith(":")) {
+					pendingLine = line;
+					openParens = 0;
+					for (i in 0...line.length) {
+						final c = line.charAt(i);
+						if (c == "(")
+							openParens++;
+						else if (c == ")")
+							openParens--;
+					}
+					// If parens are balanced and has colon, it's complete
+					if (openParens <= 0 && trimmed.indexOf(":") != -1) {
+						result.push(line);
+						pendingLine = null;
+						openParens = 0;
+					}
+				} else {
+					result.push(line);
+				}
+			}
+		}
+
+		// Add any remaining pending line
+		if (pendingLine != null) {
+			result.push(pendingLine);
+		}
+
+		return result.join("\n");
+	}
+
+	/**
+		Parse GDScript content string.
+	**/
+	public static function parseContent(content:String, filePath:String):Null<GDScriptClass> {
+		// Pre-process: join multi-line function declarations
+		final processedContent = joinMultilineDeclarations(content);
+		final lines = processedContent.split("\n");
+
+		var className:Null<String> = null;
+		var extends_:Null<String> = null;
+		final signals:Array<GDScriptSignal> = [];
+		final methods:Array<GDScriptMethod> = [];
+		final properties:Array<GDScriptProperty> = [];
+		final constants:Array<GDScriptConstant> = [];
+
+		var lastComment:Null<String> = null;
+		var isExportNext = false;
+		var insideFunction = false;
+
+		for (line in lines) {
+			final trimmed = line.trim();
+
+			// Check indentation - class level declarations have no indentation
+			final isClassLevel = line.length > 0 && (line.charAt(0) != "\t" && line.charAt(0) != " ");
+
+			// Track if we're inside a function
+			if (isClassLevel && (trimmed.startsWith("func ") || trimmed.startsWith("static func "))) {
+				insideFunction = true;
+			} else if (isClassLevel && trimmed.length > 0 && !trimmed.startsWith("#") && !trimmed.startsWith("@")) {
+				// Any other class-level non-comment, non-annotation line means we're out of func
+				insideFunction = false;
+			}
+
+			// Skip empty lines
+			if (trimmed.length == 0) {
+				lastComment = null;
+				isExportNext = false;
+				continue;
+			}
+
+			// Only process class-level declarations
+			if (!isClassLevel) {
+				continue;
+			}
+
+			// Capture comments for documentation
+			if (trimmed.startsWith("##")) {
+				// Doc comment
+				lastComment = trimmed.substr(2).trim();
+				continue;
+			} else if (trimmed.startsWith("#")) {
+				// Regular comment - could be doc
+				if (lastComment == null) {
+					lastComment = trimmed.substr(1).trim();
+				}
+				continue;
+			}
+
+			// Check for @export annotation
+			if (trimmed.startsWith("@export")) {
+				isExportNext = true;
+				continue;
+			}
+
+			// Parse class_name (may include inline extends)
+			if (trimmed.startsWith("class_name ")) {
+				final rest = trimmed.substr("class_name ".length).trim();
+				// Handle: class_name MyClass extends BaseClass
+				if (rest.indexOf(" extends ") != -1) {
+					final parts = rest.split(" extends ");
+					className = parts[0].trim();
+					extends_ = parts[1].trim();
+				} else {
+					className = rest;
+				}
+				lastComment = null;
+				continue;
+			}
+
+			// Parse extends
+			if (trimmed.startsWith("extends ")) {
+				extends_ = trimmed.substr("extends ".length).trim();
+				lastComment = null;
+				continue;
+			}
+
+			// Parse signal
+			if (trimmed.startsWith("signal ")) {
+				final signal = parseSignal(trimmed, lastComment);
+				if (signal != null) {
+					signals.push(signal);
+				}
+				lastComment = null;
+				continue;
+			}
+
+			// Parse const
+			if (trimmed.startsWith("const ")) {
+				final constant = parseConstant(trimmed, lastComment);
+				if (constant != null) {
+					constants.push(constant);
+				}
+				lastComment = null;
+				continue;
+			}
+
+			// Parse var (only at class level, not inside functions)
+			if (trimmed.startsWith("var ") || (isExportNext && trimmed.startsWith("var "))) {
+				final prop = parseProperty(trimmed, isExportNext, lastComment);
+				if (prop != null) {
+					// Check for duplicates
+					var isDuplicate = false;
+					for (existing in properties) {
+						if (existing.name == prop.name) {
+							isDuplicate = true;
+							break;
+						}
+					}
+					if (!isDuplicate) {
+						properties.push(prop);
+					}
+				}
+				lastComment = null;
+				isExportNext = false;
+				continue;
+			}
+
+			// Parse func
+			if (trimmed.startsWith("func ") || trimmed.startsWith("static func ")) {
+				final method = parseMethod(trimmed, lastComment);
+				if (method != null) {
+					methods.push(method);
+				}
+				lastComment = null;
+				insideFunction = true;
+				continue;
+			}
+
+			// Reset state for other lines
+			if (!trimmed.startsWith("@")) {
+				isExportNext = false;
+			}
+		}
+
+		// If no class_name, derive from filename
+		if (className == null) {
+			final filename = haxe.io.Path.withoutDirectory(filePath);
+			className = haxe.io.Path.withoutExtension(filename);
+			// Convert snake_case to PascalCase
+			className = snakeToPascal(className);
+		}
+
+		return {
+			name: className,
+			extends_: extends_,
+			filePath: filePath,
+			signals: signals,
+			methods: methods,
+			properties: properties,
+			constants: constants
+		};
+	}
+
+	static function parseSignal(line:String, comment:Null<String>):Null<GDScriptSignal> {
+		// signal my_signal
+		// signal my_signal(arg1, arg2: int)
+		final withoutSignal = line.substr("signal ".length).trim();
+
+		final parenPos = withoutSignal.indexOf("(");
+		if (parenPos == -1) {
+			// No arguments
+			return {
+				name: withoutSignal,
+				arguments: [],
+				description: comment
+			};
+		}
+
+		final name = withoutSignal.substr(0, parenPos).trim();
+		final argsStr = withoutSignal.substring(parenPos + 1, withoutSignal.lastIndexOf(")"));
+		final args = parseArguments(argsStr);
+
+		return {
+			name: name,
+			arguments: args,
+			description: comment
+		};
+	}
+
+	static function parseMethod(line:String, comment:Null<String>):Null<GDScriptMethod> {
+		// func my_func():
+		// func my_func(arg1: int) -> String:
+		// static func my_func():
+
+		final isStatic = line.startsWith("static ");
+		final withoutStatic = isStatic ? line.substr("static ".length).trim() : line;
+		final withoutFunc = withoutStatic.substr("func ".length).trim();
+
+		// Remove trailing colon
+		var cleaned = withoutFunc;
+		if (cleaned.endsWith(":")) {
+			cleaned = cleaned.substr(0, cleaned.length - 1);
+		}
+
+		final parenPos = cleaned.indexOf("(");
+		if (parenPos == -1) {
+			return null;
+		}
+
+		final name = cleaned.substr(0, parenPos).trim();
+
+		final closeParenPos = cleaned.indexOf(")");
+		final argsStr = cleaned.substring(parenPos + 1, closeParenPos);
+		final args = parseArguments(argsStr);
+
+		// Check for return type
+		var returnType:Null<String> = null;
+		final arrowPos = cleaned.indexOf("->");
+		if (arrowPos != -1) {
+			returnType = cleaned.substr(arrowPos + 2).trim();
+		}
+
+		return {
+			name: name,
+			arguments: args,
+			returnType: returnType,
+			isStatic: isStatic,
+			description: comment
+		};
+	}
+
+	static function parseProperty(line:String, isExport:Bool, comment:Null<String>):Null<GDScriptProperty> {
+		// var my_var
+		// var my_var: int
+		// var my_var: int = 5
+		// var my_var = 5
+
+		final withoutVar = line.substr("var ".length).trim();
+
+		var name:String;
+		var type:Null<String> = null;
+		var defaultValue:Null<String> = null;
+
+		final colonPos = withoutVar.indexOf(":");
+		final equalsPos = withoutVar.indexOf("=");
+
+		if (colonPos != -1 && (equalsPos == -1 || colonPos < equalsPos)) {
+			name = withoutVar.substr(0, colonPos).trim();
+			if (equalsPos != -1) {
+				type = withoutVar.substring(colonPos + 1, equalsPos).trim();
+				defaultValue = withoutVar.substr(equalsPos + 1).trim();
+			} else {
+				type = withoutVar.substr(colonPos + 1).trim();
+			}
+		} else if (equalsPos != -1) {
+			name = withoutVar.substr(0, equalsPos).trim();
+			defaultValue = withoutVar.substr(equalsPos + 1).trim();
+		} else {
+			name = withoutVar;
+		}
+
+		// Skip private vars
+		if (name.startsWith("_")) {
+			return null;
+		}
+
+		return {
+			name: name,
+			type: type,
+			defaultValue: defaultValue,
+			isExport: isExport,
+			isConst: false,
+			description: comment
+		};
+	}
+
+	static function parseConstant(line:String, comment:Null<String>):Null<GDScriptConstant> {
+		// const MY_CONST = 5
+		// const MY_CONST: int = 5
+
+		final withoutConst = line.substr("const ".length).trim();
+
+		var name:String;
+		var type:Null<String> = null;
+		var value:Null<String> = null;
+
+		final colonPos = withoutConst.indexOf(":");
+		final equalsPos = withoutConst.indexOf("=");
+
+		if (colonPos != -1 && equalsPos != -1 && colonPos < equalsPos) {
+			name = withoutConst.substr(0, colonPos).trim();
+			type = withoutConst.substring(colonPos + 1, equalsPos).trim();
+			value = withoutConst.substr(equalsPos + 1).trim();
+		} else if (equalsPos != -1) {
+			name = withoutConst.substr(0, equalsPos).trim();
+			value = withoutConst.substr(equalsPos + 1).trim();
+		} else {
+			name = withoutConst;
+		}
+
+		return {
+			name: name,
+			type: type,
+			value: value,
+			description: comment
+		};
+	}
+
+	static function parseArguments(argsStr:String):Array<GDScriptArg> {
+		if (argsStr.trim().length == 0) {
+			return [];
+		}
+
+		final args:Array<GDScriptArg> = [];
+		final parts = argsStr.split(",");
+
+		for (part in parts) {
+			final trimmed = part.trim();
+			if (trimmed.length == 0)
+				continue;
+
+			var name:String;
+			var type:Null<String> = null;
+			var defaultValue:Null<String> = null;
+
+			final colonPos = trimmed.indexOf(":");
+			final equalsPos = trimmed.indexOf("=");
+
+			if (colonPos != -1) {
+				name = trimmed.substr(0, colonPos).trim();
+				if (equalsPos != -1 && equalsPos > colonPos) {
+					type = trimmed.substring(colonPos + 1, equalsPos).trim();
+					defaultValue = trimmed.substr(equalsPos + 1).trim();
+				} else {
+					type = trimmed.substr(colonPos + 1).trim();
+				}
+			} else if (equalsPos != -1) {
+				name = trimmed.substr(0, equalsPos).trim();
+				defaultValue = trimmed.substr(equalsPos + 1).trim();
+			} else {
+				name = trimmed;
+			}
+
+			args.push({
+				name: name,
+				type: type,
+				defaultValue: defaultValue
+			});
+		}
+
+		return args;
+	}
+
+	static function snakeToPascal(s:String):String {
+		final parts = s.split("_");
+		return parts.map(p -> p.length > 0 ? p.charAt(0).toUpperCase() + p.substr(1) : "").join("");
+	}
+}

--- a/src/godot/gdscript/GDScriptParser.hx
+++ b/src/godot/gdscript/GDScriptParser.hx
@@ -225,7 +225,30 @@ class GDScriptParser {
 
 			// Check for @export annotation
 			if (trimmed.startsWith("@export")) {
-				isExportNext = true;
+				// Check if it's inline: @export var name
+				if (trimmed.indexOf(" var ") != -1) {
+					// Extract the var part and parse it
+					final varPart = trimmed.substr(trimmed.indexOf("var "));
+					final prop = parseProperty(varPart, true, lastComment);
+					if (prop != null) {
+						// Check for duplicates
+						var isDuplicate = false;
+						for (existing in properties) {
+							if (existing.name == prop.name) {
+								isDuplicate = true;
+								break;
+							}
+						}
+						if (!isDuplicate) {
+							properties.push(prop);
+						}
+					}
+					lastComment = null;
+					isExportNext = false;
+				} else {
+					// @export on its own line, next line should be var
+					isExportNext = true;
+				}
 				continue;
 			}
 

--- a/src/godot/generation/GenerateClass.hx
+++ b/src/godot/generation/GenerateClass.hx
@@ -1,14 +1,12 @@
 package godot.generation;
 
 import haxe.macro.Expr;
-
 import godot.BindingsUtil as Util;
 import godot.extension_api.Class as GodotClass;
 import godot.extension_api.Class.ClassMethod;
 import godot.generation.GenerateEnum;
 
 // ---
-
 using godot.bindings.NullableArrayTools;
 using godot.bindings.NullTools;
 
@@ -20,102 +18,102 @@ class GenerateClass {
 	/**
 		Names of the loaded Godot singletons.
 	**/
-	static var singletons: Map<String, Bool> = [];
+	static var singletons:Map<String, Bool> = [];
 
 	/**
 		This is a map of builtin classes that have been validated to have
 		a constructor that would work with `@:reassignOnSubfieldEdit`.
 	**/
-	static var validatedROSEBuiltinClasses: Map<String, Array<String>> = [];
+	static var validatedROSEBuiltinClasses:Map<String, Array<String>> = [];
 
 	/**
 		Preemptively iterate through the "classes" and figure out which ones
 		extend from the `generateHierarchyMeta` list.
 	**/
-	static function generateHierarchyData(classes: Array<GodotClass>, bindings: Bindings): Map<String, Map<String, Bool>> {
+	static function generateHierarchyData(classes:Array<GodotClass>, bindings:Bindings):Map<String, Map<String, Bool>> {
 		final options = bindings.options;
 
-		final hierarchyData: Map<String, Map<String, Bool>> = [];
-		final unprocessedChildren: Map<String, Array<GodotClass>> = [];
+		final hierarchyData:Map<String, Map<String, Bool>> = [];
+		final unprocessedChildren:Map<String, Array<GodotClass>> = [];
 
-		function processHierarchy(cls: GodotClass) {
-			if(hierarchyData.exists(cls.name)) {
+		function processHierarchy(cls:GodotClass) {
+			if (hierarchyData.exists(cls.name)) {
 				return;
 			}
 
 			final isBase = options.generateHierarchyMeta.contains(cls.name);
 			final superClass = cls.inherits;
-			if(superClass == null || superClass == "Object") {
-				final map: Map<String, Bool> = [];
-				for(m in options.generateHierarchyMeta) {
+			if (superClass == null || superClass == "Object") {
+				final map:Map<String, Bool> = [];
+				for (m in options.generateHierarchyMeta) {
 					map.set(m, cls.name == m);
 				}
 				hierarchyData.set(cls.name, map);
-			} else if(hierarchyData.exists(superClass)) {
+			} else if (hierarchyData.exists(superClass)) {
 				final map = Reflect.copy(hierarchyData.get(superClass));
-				if(map == null) {
+				if (map == null) {
 					throw "Reflect.copy failed.";
 				}
-				if(isBase) {
+				if (isBase) {
 					map.set(cls.name, true);
 				}
 				hierarchyData.set(cls.name, map);
 			} else {
-				if(!unprocessedChildren.exists(superClass)) {
+				if (!unprocessedChildren.exists(superClass)) {
 					unprocessedChildren.set(superClass, []);
 				}
 				unprocessedChildren.get(superClass).trustMe().push(cls);
 				return;
 			}
 
-			if(unprocessedChildren.exists(cls.name)) {
-				for(child in unprocessedChildren.get(cls.name).trustMe()) {
+			if (unprocessedChildren.exists(cls.name)) {
+				for (child in unprocessedChildren.get(cls.name).trustMe()) {
 					processHierarchy(child);
 				}
 				unprocessedChildren.remove(cls.name);
 			}
 		}
 
-		for(cls in classes) {
+		for (cls in classes) {
 			processHierarchy(cls);
 		}
 
 		return hierarchyData;
 	}
 
-	static var methodsMap: Map<String, Map<String, { method: ClassMethod, inParentClass: Bool }>> = [];
+	static var methodsMap:Map<String, Map<String, {method:ClassMethod, inParentClass:Bool}>> = [];
 
 	/**
 		Generates and adds all type definitions from `classes`.
 	**/
-	public static function generate(data: ExtensionApi, bindings: Bindings, result: Array<TypeDefinition>) {
+	public static function generate(data:ExtensionApi, bindings:Bindings, result:Array<TypeDefinition>) {
 		final options = bindings.options;
 
 		// Figure out which classes are Singletons
 		singletons = [];
-		if(data.singletons != null) {
-			for(singleton in data.singletons.denullify()) {
+		if (data.singletons != null) {
+			for (singleton in data.singletons.denullify()) {
 				singletons.set(singleton.name, true);
 			}
 		}
 
 		// Get reference to classes
-		final classes: Map<String, GodotClass> = [];
-		for(cls in data.classes) {
+		final classes:Map<String, GodotClass> = [];
+		for (cls in data.classes) {
 			classes.set(cls.name, cls);
 		}
 
 		// Preprocessing...
-		for(cls in data.classes) {
+		for (cls in data.classes) {
 			// Make map of all methods in all classes
-			final methodMap: Map<String, { method: ClassMethod, inParentClass: Bool }> = [];
-			var currentClass: Null<GodotClass> = cls;
+			final methodMap:Map<String, {method:ClassMethod, inParentClass:Bool}> = [];
+			var currentClass:Null<GodotClass> = cls;
 			var inParentClass = false;
-			while(currentClass != null) {
-				for(method in currentClass.methods.denullify()) {
+			while (currentClass != null) {
+				for (method in currentClass.methods.denullify()) {
 					// Do not set method if child method already exists
-					if(!methodMap.exists(method.name)) {
-						methodMap.set(method.name, { method: method, inParentClass: inParentClass });
+					if (!methodMap.exists(method.name)) {
+						methodMap.set(method.name, {method: method, inParentClass: inParentClass});
 					}
 				}
 				currentClass = {
@@ -127,19 +125,19 @@ class GenerateClass {
 			methodsMap.set(cls.name, methodMap);
 
 			// Add to global enums map
-			for(e in cls.enums.denullify()) {
+			for (e in cls.enums.denullify()) {
 				bindings.globalEnums.set(cls.name + "_" + e.name, e);
 			}
 		}
 
 		// Generate bindings for "classes"
 		final hierarchyData = options.generateHierarchyMeta.length > 0 ? generateHierarchyData(data.classes, bindings) : null;
-		for(cls in data.classes) {
+		for (cls in data.classes) {
 			final typeDefinition = generateClass(cls, bindings);
 
 			// Generate additional metadata from `generateHierarchyMeta`
-			if(hierarchyData != null && hierarchyData.exists(cls.name)) {
-				for(className => inherits in hierarchyData.get(cls.name).trustMe()) {
+			if (hierarchyData != null && hierarchyData.exists(cls.name)) {
+				for (className => inherits in hierarchyData.get(cls.name).trustMe()) {
 					final m = typeDefinition.meta ?? [];
 					m.push({
 						name: ":is_" + className.toLowerCase(),
@@ -152,8 +150,9 @@ class GenerateClass {
 
 			result.push(typeDefinition);
 
-			for(e in cls.enums.denullify()) {
-				result.push(GenerateEnum.generateGlobalEnum(e, bindings, Util.processTypeName(cls.name), "godot_cpp/classes/" + Util.camelToSnake(cls.name) + ".hpp"));
+			for (e in cls.enums.denullify()) {
+				result.push(GenerateEnum.generateGlobalEnum(e, bindings, Util.processTypeName(cls.name),
+					"godot_cpp/classes/" + Util.camelToSnake(cls.name) + ".hpp"));
 			}
 		}
 	}
@@ -161,16 +160,16 @@ class GenerateClass {
 	/**
 		Generates a single `TypeDefinition` for the `Class`.
 	**/
-	static function generateClass(cls: GodotClass, bindings: Bindings): TypeDefinition {
+	static function generateClass(cls:GodotClass, bindings:Bindings):TypeDefinition {
 		final options = bindings.options;
 
-		final fields: Array<Field> = [];
+		final fields:Array<Field> = [];
 		final fieldAccess = [APublic];
 
 		final isSingleton = singletons.exists(cls.name);
 
 		// Assume every class has a no-argument constructor.
-		if(!isSingleton) {
+		if (!isSingleton) {
 			fields.push({
 				name: "new",
 				pos: Util.makeEmptyPosition(),
@@ -182,33 +181,31 @@ class GenerateClass {
 			});
 		}
 
-		for(constant in cls.constants.denullify()) {
+		for (constant in cls.constants.denullify()) {
 			fields.push({
 				name: Util.processIdentifier(constant.name),
 				pos: Util.makeEmptyPosition(),
 				access: fieldAccess.concat([AStatic]),
-				kind: FVar(macro : Int,
-					// Cannot have value on extern, but if we could we'd use: macro $v{constant.value}),
-					null
-				),
+				kind: FVar(macro :Int, // Cannot have value on extern, but if we could we'd use: macro $v{constant.value}),
+					null),
 				meta: [],
 				doc: Util.processDescription(constant.description)
 			});
 		}
 
 		// Validate property types and their getter/setter types
-		final getterExpectedType: Map<String, { name: String, type: String }> = [];
-		final setterExpectedType: Map<String, { name: String, type: String }> = [];
-		final getterSetterFound: Map<String, { sourceProperty: String, exists: Bool }> = [];
-		final extraPropertyMeta: Map<String, Metadata> = [];
-		for(property in cls.properties.denullify()) {
-			if(property.getter != null) {
+		final getterExpectedType:Map<String, {name:String, type:String}> = [];
+		final setterExpectedType:Map<String, {name:String, type:String}> = [];
+		final getterSetterFound:Map<String, {sourceProperty:String, exists:Bool}> = [];
+		final extraPropertyMeta:Map<String, Metadata> = [];
+		for (property in cls.properties.denullify()) {
+			if (property.getter != null) {
 				getterExpectedType.set(property.getter, property);
-				getterSetterFound.set(property.getter, { sourceProperty: property.name, exists: false });
+				getterSetterFound.set(property.getter, {sourceProperty: property.name, exists: false});
 			}
-			if(property.setter != null) {
+			if (property.setter != null) {
 				setterExpectedType.set(property.setter, property);
-				getterSetterFound.set(property.setter, { sourceProperty: property.name, exists: false });
+				getterSetterFound.set(property.setter, {sourceProperty: property.name, exists: false});
 			}
 
 			extraPropertyMeta.set(property.name, []);
@@ -216,43 +213,38 @@ class GenerateClass {
 
 		// Let's ignore properties who don't have matching types with their getters/setters for the time being.
 		// They can still be used by calling the getter/setter function directly.
-		final ignoreProperties: Map<String, Bool> = [];
-		function prop(p: String) {
-			// return if(StringTools.startsWith(p, "enum::")) "int";
-			// else if(StringTools.startsWith(p, "bitfield::")) "int";
-			// Uncomment once a solution to treat Strings and StringNames the same is found...
-			// else if(p == "StringName") "String";
+		final ignoreProperties:Map<String, Bool> = [];
+		function prop(p:String) {
 			return p;
 		}
 
 		final mappedMethods = methodsMap.get(cls.name);
-		if(mappedMethods != null) {
-			for(methodName => methodData in mappedMethods /* cls.methods.denullify() */) {
+		if (mappedMethods != null) {
+			for (methodName => methodData in mappedMethods) {
 				final method = methodData.method;
 				final methodName = method.name;
 				final getterSetterData = getterSetterFound.get(methodName);
-				if(getterSetterData != null) {
+				if (getterSetterData != null) {
 					getterSetterData.exists = true;
 				}
 
-				if(getterExpectedType.exists(methodName)) {
+				if (getterExpectedType.exists(methodName)) {
 					final property = getterExpectedType.get(methodName).trustMe();
-					if(method.return_value == null || prop(method.return_value.type) != prop(property.type)) {
+					if (method.return_value == null || prop(method.return_value.type) != prop(property.type)) {
 						#if godot_api_bindings_debug
 						Sys.println('Property and getter types do not match.\n${cls.name} { func ${methodName}(...) -> ${method.return_value.type}, prop: ${property.name}: ${property.type} }');
 						#end
 						ignoreProperties.set(property.name, true);
-					} else if(methodData.inParentClass && methodName != "get_" + property.name) {
+					} else if (methodData.inParentClass && methodName != "get_" + property.name) {
 						#if eval
-						extraPropertyMeta.get(property.name).push(Util.makeMetadataEntry(
-							macro godot_bindings_gen_prepend($v{'\tpublic extern inline function get_${property.name}() { return ${methodName}(); }'})
-						));
+						extraPropertyMeta.get(property.name)
+							.push(Util.makeMetadataEntry(macro godot_bindings_gen_prepend($v{'\tpublic extern inline function get_${property.name}() { return ${methodName}(); }'})));
 						#end
 					}
-				} else if(setterExpectedType.exists(methodName)) {
+				} else if (setterExpectedType.exists(methodName)) {
 					final property = setterExpectedType.get(methodName).trustMe();
 					final args = method.arguments.denullify();
-					if(args.length == 0 || prop(args[args.length - 1].type) != prop(property.type)) {
+					if (args.length == 0 || prop(args[args.length - 1].type) != prop(property.type)) {
 						#if godot_api_bindings_debug
 						Sys.println('Property and setter types do not match.\n${cls.name} { func ${methodName}(..., v: ${args[args.length - 1].type}), prop: ${property.name}: ${property.type} }');
 						#end
@@ -264,8 +256,8 @@ class GenerateClass {
 
 		// Check for non-existant methods.
 		// Let's ignore these properties too.
-		for(_ => data in getterSetterFound) {
-			if(!data.exists) {
+		for (_ => data in getterSetterFound) {
+			if (!data.exists) {
 				ignoreProperties.set(data.sourceProperty, true);
 				#if godot_api_bindings_debug
 				Sys.println('${cls.name}.$name doesn\'t exist');
@@ -273,12 +265,12 @@ class GenerateClass {
 			}
 		}
 
-		final propertyRenames: Map<String, String> = [];
-		final existingRenames: Map<String, Bool> = [];
-		final setters: Map<String, String> = [];
+		final propertyRenames:Map<String, String> = [];
+		final existingRenames:Map<String, Bool> = [];
+		final setters:Map<String, String> = [];
 
-		for(property in cls.properties.denullify()) {
-			if(StringTools.contains(property.type, ",") || StringTools.contains(property.type, "/")) {
+		for (property in cls.properties.denullify()) {
+			if (StringTools.contains(property.type, ",") || StringTools.contains(property.type, "/")) {
 				continue;
 			}
 
@@ -294,16 +286,15 @@ class GenerateClass {
 			// Example: `Control.anchor_XXX` properties and their setter: `Control._set_anchor`
 			final hasSetter = property.setter != null && !StringTools.startsWith(property.setter, "_");
 
-			if(!ignoreProperty && !isSpecialIndexedProp) {
-				// TODO: check for private getter??
-				if(property.getter != null && property.getter != "get_" + name) {
+			if (!ignoreProperty && !isSpecialIndexedProp) {
+				if (property.getter != null && property.getter != "get_" + name) {
 					propertyRenames.set(property.getter, "get_" + name);
 					existingRenames.set("get_" + name, true);
 				}
 
-				if(hasSetter) {
+				if (hasSetter) {
 					final setter = property.setter.trustMe();
-					if(setter != "set_" + name) {
+					if (setter != "set_" + name) {
 						propertyRenames.set(setter, "set_" + name);
 						existingRenames.set("set_" + name, true);
 					}
@@ -311,14 +302,11 @@ class GenerateClass {
 				}
 			}
 
-			final data = if(isSingleton) {
+			final data = if (isSingleton) {
 				{
 					access: fieldAccess.concat([AStatic]),
-					meta: !options.cpp ? [] : Util.makeMetadata(
-						#if eval
-						macro godot_bindings_gen_prepend($v{'#if !${Bindings.cxxInlineSingletonsCondition}'}),
-						macro godot_bindings_gen_append("#end")
-						#end
+					meta: !options.cpp ? [] : Util.makeMetadata(#if eval macro godot_bindings_gen_prepend($v{'#if !${Bindings.cxxInlineSingletonsCondition}'}),
+						macro godot_bindings_gen_append("#end") #end
 					)
 				}
 			} else {
@@ -331,25 +319,26 @@ class GenerateClass {
 			var propertyMeta = extraPropertyMeta.get(property.name) ?? [];
 
 			// Setup property if we're not ignoring it.
-			if(!ignoreProperty) {
+			if (!ignoreProperty) {
 				// For the "special indexed" properties, let's generate their own set/get inline functions.
-				if(isSpecialIndexedProp) {
+				if (isSpecialIndexedProp) {
 					final typeString = haxe.macro.ComplexTypeTools.toString(bindings.getType(property.type));
 
 					var enumName = null;
 					final enumIndex = property.index;
-					if(enumIndex == null) throw "Impossible";
+					if (enumIndex == null)
+						throw "Impossible";
 
 					var resultingValue = Std.string(enumIndex);
 
-					for(m in cls.methods.denullify()) {
-						if(m.name == property.getter) {
+					for (m in cls.methods.denullify()) {
+						if (m.name == property.getter) {
 							enumName = m.arguments.denullify()[0].trustMe().type;
 							break;
 						}
 					}
 
-					if(enumName != null && StringTools.startsWith(enumName, "enum::")) {
+					if (enumName != null && StringTools.startsWith(enumName, "enum::")) {
 						final enumPack = enumName.substr("enum::".length).split(".");
 						final enumClassName = enumPack[0];
 						final enumLocalName = enumPack[enumPack.length - 1];
@@ -357,14 +346,15 @@ class GenerateClass {
 
 						var enumObj = bindings.globalEnums.get(enumHaxeName);
 
-						if(enumObj != null) {
+						if (enumObj != null) {
 							var name = null;
-							for(v in enumObj.values) {
-								if(v.value == enumIndex) {
+							for (v in enumObj.values) {
+								if (v.value == enumIndex) {
 									name = v.name;
 								}
 							}
-							if(name != null) resultingValue = name;
+							if (name != null)
+								resultingValue = name;
 						}
 					}
 
@@ -378,34 +368,32 @@ class GenerateClass {
 	}\n';
 
 					#if eval
-					propertyMeta.push(Util.makeMetadataEntry(
-						macro godot_bindings_gen_prepend($v{'$getter\n$setter'})
-					));
+					propertyMeta.push(Util.makeMetadataEntry(macro godot_bindings_gen_prepend($v{'$getter\n$setter'})));
 					#end
 				}
 
 				// @:reassignOnSubfieldEdit
-				if(hasSetter) {
+				if (hasSetter) {
 					final builtinClassType = bindings.builtinClasses.get(property.type);
-					if(builtinClassType != null) {
+					if (builtinClassType != null) {
 						var margs = validatedROSEBuiltinClasses.get(property.type);
-						if(margs == null) {
+						if (margs == null) {
 							margs = [];
 
 							final members = builtinClassType.members.denullify();
-							final membersMap: Map<String, String> = [];
-							for(m in members) {
+							final membersMap:Map<String, String> = [];
+							for (m in members) {
 								membersMap.set(m.name, m.type);
 							}
-							for(c in builtinClassType.constructors.denullify()) {
+							for (c in builtinClassType.constructors.denullify()) {
 								final constructorArgs = c.arguments.denullify();
 
 								// Found the constructor!
-								if(constructorArgs.length == members.length) {
+								if (constructorArgs.length == members.length) {
 									var found = true;
-									for(carg in constructorArgs) {
+									for (carg in constructorArgs) {
 										final memberType = membersMap.get(carg.name);
-										if(memberType != null && memberType == carg.type) {
+										if (memberType != null && memberType == carg.type) {
 											margs.push(carg.name);
 										} else {
 											margs = []; // Clear and try again...
@@ -413,7 +401,7 @@ class GenerateClass {
 											break;
 										}
 									}
-									if(found) {
+									if (found) {
 										break;
 									}
 								}
@@ -422,9 +410,9 @@ class GenerateClass {
 							validatedROSEBuiltinClasses.set(property.type, margs);
 						}
 
-						propertyMeta.push(Util.makeMetadataEntry(
-							macro reassignOnSubfieldEdit($a{["set_" + name + "_impl"].concat(margs).map(m -> macro $i{m})})
-						));
+						propertyMeta.push(Util.makeMetadataEntry(macro reassignOnSubfieldEdit($a{
+							["set_" + name + "_impl"].concat(margs).map(m -> macro $i{m})
+						})));
 					}
 				}
 
@@ -433,15 +421,11 @@ class GenerateClass {
 					pos: Util.makeEmptyPosition(),
 					access: data.access,
 					kind: FProp("get", property.setter == null ? "never" : "set", bindings.getType(property.type)),
-					meta: Util.makeMetadata(
-						#if eval
-						macro index($v{property.index}),
-						macro getter($v{property.getter}),
-						macro setter($v{property.setter}),
-						macro godot_bindings_gen_prepend($v{'#if use_properties'}),
-						macro godot_bindings_gen_append("#else")
-						#end
-					).concat(data.meta).concat(propertyMeta),
+					meta: Util.makeMetadata(#if eval macro index($v{property.index}), macro getter($v{property.getter}), macro setter($v{property.setter}),
+						macro godot_bindings_gen_prepend($v{'#if use_properties'}), macro godot_bindings_gen_append("#else") #end
+					)
+						.concat(data.meta)
+						.concat(propertyMeta),
 					doc: Util.processDescription(property.description)
 				});
 
@@ -460,48 +444,32 @@ class GenerateClass {
 				pos: Util.makeEmptyPosition(),
 				access: data.access,
 				kind: FVar(bindings.getType(property.type)),
-				meta: Util.makeMetadata(
-					#if eval
-					macro index($v{property.index}),
-					macro getter($v{property.getter}),
-					macro setter($v{property.setter})
-					#end
-				).concat(data.meta),
+				meta: Util.makeMetadata(#if eval macro index($v{property.index}), macro getter($v{property.getter}), macro setter($v{property.setter}) #end)
+					.concat(data.meta),
 				doc: Util.processDescription(property.description)
 			});
 		}
 
-		for(method in cls.methods.denullify()) {
-			final metadata = Util.makeMetadata(
-				#if eval
-				macro is_const($v{method.is_const}),
-				macro is_static($v{method.is_static}),
-				macro is_vararg($v{method.is_vararg}),
-				macro is_virtual($v{method.is_virtual}),
-				macro hash($v{method.hash}),
-				macro hash_compatibility($v{method.hash_compatibility}),
-				macro nativeName($v{method.name})
-				#end
-			);
+		for (method in cls.methods.denullify()) {
+			final metadata = Util.makeMetadata(#if eval macro is_const($v{method.is_const}), macro is_static($v{method.is_static}),
+				macro is_vararg($v{method.is_vararg}), macro is_virtual($v{method.is_virtual}), macro hash($v{method.hash}),
+				macro hash_compatibility($v{method.hash_compatibility}), macro nativeName($v{method.name}) #end);
 
-			if(method.return_value != null) {
+			if (method.return_value != null) {
 				#if eval
-				metadata.unshift(
-					Util.makeMetadata(
-						macro return_value_meta($v{method.return_value.meta})
-					)[0]
-				);
+				metadata.unshift(Util.makeMetadata(macro return_value_meta($v{method.return_value.meta}))[0]);
 				#end
 			}
 
 			var hasCppType = StringTools.endsWith(method.return_value?.type ?? "", "*");
-			for(a in method.arguments.denullify()) {
-				if(StringTools.endsWith(a.type, "*")) {
+			for (a in method.arguments.denullify()) {
+				if (StringTools.endsWith(a.type, "*")) {
 					hasCppType = true;
 					break;
 				}
 			}
-			if(hasCppType) continue;
+			if (hasCppType)
+				continue;
 
 			var name = Util.processIdentifier(method.name);
 			final originalName = name;
@@ -509,7 +477,7 @@ class GenerateClass {
 			final setterType = setters.get(name);
 
 			var wasRenamed = false;
-			final nativeMeta = if(propertyRenames.exists(name)) {
+			final nativeMeta = if (propertyRenames.exists(name)) {
 				wasRenamed = true;
 				final result = Util.makeMetadata(#if eval macro $v{'#if use_properties ${options.nativeNameMeta}'}($v{name}) #end);
 				name = propertyRenames.get(name).trustMe();
@@ -519,84 +487,82 @@ class GenerateClass {
 			};
 
 			var preimplName = name;
-			if(!isSingleton && setterType != null) {
+			if (!isSingleton && setterType != null) {
 				name += "_impl";
 			}
 
-			function addField(
-				overrideName: Null<String> = null,
-				extraMetadata: Null<Array<MetadataEntry>> = null,
-				additionalAccess: Null<Array<Access>> = null,
-				expr: Null<Expr> = null
-			) {
-				
-
+			function addField(overrideName:Null<String> = null, extraMetadata:Null<Array<MetadataEntry>> = null, additionalAccess:Null<Array<Access>> = null,
+					expr:Null<Expr> = null) {
 				final access = fieldAccess.copy();
-				if(method.is_static) {
+				if (method.is_static) {
 					access.push(AStatic);
 				}
-				if(additionalAccess != null) {
-					for(a in additionalAccess) access.push(a);
+				if (additionalAccess != null) {
+					for (a in additionalAccess)
+						access.push(a);
 				}
+
+				// Build function arguments list
+				final functionArgs:Array<FunctionArg> = method.arguments.maybeMap(function(godotArg, index):FunctionArg {
+					final value = bindings.getValue(godotArg);
+					var opt:Null<Bool> = null;
+
+					// Has default value that cannot be expressed in Haxe.
+					// Reflaxe/GDScript can use @:default_value to fill the defaults.
+					// Not sure how to handle other targets atm.
+					if (godotArg.default_value != null && value == null)
+						opt = true;
+
+					final meta = [];
+					#if eval
+					if (godotArg.meta != null)
+						meta.push(Util.makeMetadataEntry(macro meta($v{godotArg.meta})));
+					if (godotArg.default_value != null) {
+						final valueGDScript = bindings.getValueAsGDScript(godotArg);
+						if (valueGDScript != null) {
+							meta.push(Util.makeMetadataEntry(macro default_value($v{valueGDScript})));
+							meta.push(Util.makeMetadataEntry(macro "#if gdscript :noNullPad"($v{valueGDScript})));
+						} else {
+							meta.push(Util.makeMetadataEntry(macro default_value($v{godotArg.default_value})));
+							meta.push(Util.makeMetadataEntry(macro "#if gdscript :noNullPad"($v{
+								Util.valueStringToGDScript(godotArg.default_value, godotArg.type)
+							})));
+						}
+						if (options.cpp) {
+							final cppCode = Util.valueStringToCpp(godotArg.default_value, godotArg.type);
+							final argExprs = cppCode == null ? [] : [macro $v{cppCode}];
+							meta.push(Util.makeMetadataEntry(macro "#if cxx :noNullPad"($a{argExprs})));
+						}
+					}
+
+					if (extraMetadata == null)
+						extraMetadata = [];
+					for (m in meta) {
+						final r = ~/^#if ([a-zA-Z0-9]+) (.*)$/;
+						var argMetaName = ":argMeta";
+						var paramMetaName = m.name;
+						if (r.match(paramMetaName)) {
+							argMetaName = '#if ${r.matched(1)} $argMetaName';
+							paramMetaName = r.matched(2);
+						}
+						extraMetadata.push(Util.makeMetadataEntry(macro $v{argMetaName}($v{index}, $v{paramMetaName}($a{m.params}))));
+					}
+					#end
+					return {
+						name: Util.processIdentifier(godotArg.name),
+						type: bindings.getArgumentType(godotArg.type),
+						meta: meta,
+						opt: opt,
+						value: value
+					}
+				});
 
 				fields.push({
 					name: overrideName ?? name,
 					pos: Util.makeEmptyPosition(),
 					access: access,
 					kind: FFun({
-						args: method.arguments.maybeMap(function(godotArg, index): FunctionArg {
-							final value = bindings.getValue(godotArg);
-							var opt: Null<Bool> = null;
-
-							// Has default value that cannot be expressed in Haxe.
-							// Reflaxe/GDScript can use @:default_value to fill the defaults.
-							// Not sure how to handle other targets atm.
-							if(godotArg.default_value != null && value == null) opt = true;
-
-							final meta = [];
-							#if eval
-							if(godotArg.meta != null)
-								meta.push(Util.makeMetadataEntry(macro meta($v{godotArg.meta})));
-							if(godotArg.default_value != null) {
-								final valueGDScript = bindings.getValueAsGDScript(godotArg);
-								if(valueGDScript != null) {
-									meta.push(Util.makeMetadataEntry(macro default_value($v{valueGDScript})));
-									meta.push(Util.makeMetadataEntry(macro "#if gdscript :noNullPad"($v{valueGDScript})));
-								} else {
-									meta.push(Util.makeMetadataEntry(macro default_value($v{godotArg.default_value})));
-									meta.push(Util.makeMetadataEntry(macro "#if gdscript :noNullPad"($v{Util.valueStringToGDScript(godotArg.default_value, godotArg.type)})));
-								}
-								if(options.cpp) {
-									final cppCode = Util.valueStringToCpp(godotArg.default_value, godotArg.type);
-									final argExprs = cppCode == null ? [] : [macro $v{cppCode}];
-									meta.push(Util.makeMetadataEntry(macro "#if cxx :noNullPad"($a{argExprs})));
-								}
-							}
-
-							if(extraMetadata == null) extraMetadata = [];
-							for(m in meta) {
-								final r = ~/^#if ([a-zA-Z0-9]+) (.*)$/;
-								var argMetaName = ":argMeta";
-								var paramMetaName = m.name;
-								if(r.match(paramMetaName)) {
-									argMetaName = '#if ${r.matched(1)} $argMetaName';
-									paramMetaName = r.matched(2);
-								}
-								extraMetadata.push(Util.makeMetadataEntry(
-									macro $v{argMetaName}(
-										$v{index}, $v{paramMetaName}($a{m.params})
-									)
-								));
-							}
-							#end
-							return {
-								name: Util.processIdentifier(godotArg.name),
-								type: bindings.getArgumentType(godotArg.type),
-								meta: meta,
-								opt: opt,
-								value: value
-							}
-						}),
+						args: functionArgs,
 						ret: bindings.getReturnType(method.return_value?.type),
 						expr: expr
 					}),
@@ -605,11 +571,11 @@ class GenerateClass {
 				});
 			}
 
-			if(isSingleton) {
+			if (isSingleton) {
 				// -----------------------
 				// C++ extern inline
 
-				if(options.cpp) {
+				if (options.cpp) {
 					var i = 0;
 					final margs = method.arguments.denullify();
 					final args = margs.map(a -> "{" + (i++) + "}").join(", ");
@@ -619,73 +585,51 @@ class GenerateClass {
 						[macro $v{call}].concat(margs.map(a -> macro $i{Util.processIdentifier(a.name)}))
 						#else
 						[]
-						#end;
+						#end
+						;
 					}
-					
-					addField(
-						null,
-						Util.makeMetadata(
-							#if eval
-							macro godot_bindings_gen_prepend($v{'#if ${Bindings.cxxInlineSingletonsCondition}'}),
-							macro godot_bindings_gen_append("\n#else")
-							#end
-						),
-						[AStatic, AExtern, AInline],
-						#if eval macro {
+
+					addField(null,
+						Util.makeMetadata(#if eval macro godot_bindings_gen_prepend($v{'#if ${Bindings.cxxInlineSingletonsCondition}'}),
+							macro godot_bindings_gen_append("\n#else") #end
+						), [AStatic, AExtern, AInline], #if eval
+						macro {
 							@:include($v{"godot_cpp/classes/" + Util.camelToSnake(cls.name) + ".hpp"})
 							return untyped __cpp__($a{totalArgs});
-						} #else null #end
+						}
+						#else
+						null
+						#end
 					);
 				}
 
 				// -----------------------
 				// Normal static call
-				addField(
-					null,
-					!options.cpp ? [] : Util.makeMetadata(
-						#if eval
-						macro godot_bindings_gen_append("#end")
-						#end
-					),
-					[AStatic]
-				);
+				addField(null, !options.cpp ? [] : Util.makeMetadata(#if eval macro godot_bindings_gen_append("#end") #end), [AStatic]);
 			} else {
-
 				var baseFieldMetadata = [];
 
-				if(setterType != null) {
+				if (setterType != null) {
 					final t = haxe.macro.ComplexTypeTools.toString(bindings.getReturnType(setterType));
-					addField(
-						null,
-						Util.makeMetadata(
-							#if eval
-							macro godot_bindings_gen_prepend($v{'#if use_properties
+					addField(null, Util.makeMetadata(#if eval macro godot_bindings_gen_prepend($v{
+						'#if use_properties
 	public extern inline function $preimplName(v: $t): $t {
 		${preimplName}_impl(cast v);
 		return v;
 	}
-'}),
-							macro godot_bindings_gen_append("\n#else"),
-							macro $v{options.nativeNameMeta}($v{preimplName})
-							#end
-						),
-					);
+'
+					}), macro godot_bindings_gen_append("\n#else"), macro $v{options.nativeNameMeta}($v{preimplName}) #end),);
 
-
-					baseFieldMetadata = Util.makeMetadata(
-						#if eval
-						macro godot_bindings_gen_append("\n#end")
-						#end
-					);
+					baseFieldMetadata = Util.makeMetadata(#if eval macro godot_bindings_gen_append("\n#end") #end);
 				}
 
 				// Special case to deal with Godot-CPP's `get_node<T>`.
 				// To get the behavior expected for GDScript's `get_node`, `get_node_internal` should be used.
-				if(options.cpp && cls.name == "Node" && originalName == "get_node") {
+				if (options.cpp && cls.name == "Node" && originalName == "get_node") {
 					#if eval
 					baseFieldMetadata.push(Util.makeMetadataEntry(macro $v{'#if ${Bindings.cxxFixGetNode} ${options.nativeNameMeta}'}("get_node_internal")));
 					#end
-				} else if(preimplName != originalName) {
+				} else if (preimplName != originalName) {
 					#if eval
 					baseFieldMetadata.push(Util.makeMetadataEntry(macro $v{options.nativeNameMeta}($v{originalName})));
 					#end
@@ -695,39 +639,51 @@ class GenerateClass {
 				// To prevent conflict with any Haxe getters/setters we made, add "_function" to the end.
 				final forcedName = !wasRenamed && existingRenames.exists(name) ? (preimplName + "_function") : preimplName;
 
-				addField(
-					forcedName,
-					baseFieldMetadata
-				);
+				addField(forcedName, baseFieldMetadata);
 			}
-
-			
 		}
 
-		/**TODO
-			// https://github.com/godotengine/godot/blob/93cdacbb0a30f12b2f3f5e8e06b90149deeb554b/core/extension/extension_api_dump.cpp#L1142C13-L1142C13
-			signals: MaybeArray<{
-				name: String,
-				arguments: MaybeArray<{
-					name: String,
-					type: String,
-					meta: Null<String>
-				}>,
-				description: Null<String>
-			}>,
-		**/
+		// Generate signals
+		for (signal in cls.signals.denullify()) {
+			final signalName = Util.processIdentifier(signal.name);
 
-		final meta = Util.makeMetadata(
+			// Build documentation string that includes argument types
+			var docString = signal.description ?? "";
+			final signalArgs = signal.arguments.denullify();
+			if (signalArgs.length > 0) {
+				final argsDoc = signalArgs.map(arg -> '${arg.name}: ${arg.type}').join(", ");
+				docString = 'Signal arguments: ($argsDoc)\n\n$docString';
+			}
+
+			// Build metadata for signal arguments info
+			final signalMeta:Metadata = Util.makeMetadata(#if eval macro signal, macro nativeName($v{signal.name}) #end);
+
 			#if eval
-			macro generated_godot_api,
-			macro bindings_api_type("class"),
-			macro is_refcounted($v{cls.is_refcounted}),
-			macro is_instantiable($v{cls.is_instantiable}),
-			macro api_type($v{cls.api_type})
+			// Add argument metadata for each signal argument
+			for (i => arg in signalArgs) {
+				signalMeta.push(Util.makeMetadataEntry(macro signal_arg($v{i}, $v{arg.name}, $v{arg.type})));
+			}
 			#end
-		);
 
-		if(options.cpp) {
+			final signalAccess = isSingleton ? fieldAccess.concat([AStatic]) : fieldAccess;
+
+			fields.push({
+				name: signalName,
+				pos: Util.makeEmptyPosition(),
+				access: signalAccess,
+				kind: FVar(TPath({
+					pack: bindings.getPack(),
+					name: "Signal"
+				})),
+				meta: signalMeta,
+				doc: Util.processDescription(docString)
+			});
+		}
+
+		final meta = Util.makeMetadata(#if eval macro generated_godot_api, macro bindings_api_type("class"), macro is_refcounted($v{cls.is_refcounted}),
+			macro is_instantiable($v{cls.is_instantiable}), macro api_type($v{cls.api_type}) #end);
+
+		if (options.cpp) {
 			#if eval
 			final p = "godot_cpp/classes/" + Util.camelToSnake(cls.name) + ".hpp";
 			meta.push(Util.makeMetadataEntry(macro $v{'#if ${options.cppDefine} :include'}($v{p})));


### PR DESCRIPTION
i've doing this and i i i was liooke haii >//<

# Addons (copied from the readme tehee)

### Usage

```bash
haxelib run godot-api-generator --addon path/to/addon/ [output-dir]
```

### Example

Given a GDScript addon at `addons/my_addon/`:

```gdscript
# addons/my_addon/my_class.gd
class_name MyClass extends Node

signal health_changed(old_value: int, new_value: int)

var health: int = 100
@export var max_health: int = 100

func take_damage(amount: int) -> void:
    health -= amount
```

Running:

```bash
haxelib run godot-api-generator --addon addons/my_addon/ source/
```

Generates `source/my_addon/MyClass.hx`:

```haxe
package my_addon;

@:native("MyClass") extern class MyClass extends godot.Node {
    public function new();

    @:native("health_changed") @:signal
    public var health_changed:godot.Signal;

    public var health:Int;
    @:export public var max_health:Int;

    @:native("take_damage")
    public function take_damage(amount:Int):Void;
}
```

Now you can use the addon with full type safety:

```haxe
var myClass = new MyClass();
myClass.health_changed.connect((old, new) -> trace('Health: $old -> $new'));
myClass.take_damage(25);
```

### What Gets Parsed

- `class_name` and `extends` declarations
- `signal` declarations with arguments
- `func` methods with arguments and return types
- `var` properties with types
- `const` constants
- `@export` annotations
- Multi-line function declarations

### Options

Use with `--nativeName` to use `@:nativeName` instead of `@:native`:

```bash
haxelib run godot-api-generator --nativeName --addon addons/my_addon/
```
